### PR TITLE
[STYLE-12] MainLayout 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,19 @@
 import { Route, Routes } from "react-router-dom";
 import MainPage from "./pages/MainPage";
 import BudgetManage from "./pages/BudgetManage";
-import AddExpenditurePage from "./pages/AddExpenditurePage";
+import MainLayout from "./layouts/MainLayout";
+import AddPayPage from "./pages/AddPayPage";
 
 const App: React.FC = () => {
   return (
     <Routes>
       <Route path="/" element={<MainPage />} />
-      <Route path="/budget" element={<BudgetManage />} />
-      <Route path="/addExpenditure" element={<AddExpenditurePage />} />
+      <Route element={<MainLayout title="예산관리" bgColor="bg-second-bg" />}>
+        <Route path="/budget" element={<BudgetManage />} />
+      </Route>
+      <Route element={<MainLayout title="지출 내역 추가" />}>
+        <Route path="/addpay" element={<AddPayPage />} />
+      </Route>
     </Routes>
   );
 };

--- a/src/components/AddPayInput.tsx
+++ b/src/components/AddPayInput.tsx
@@ -4,7 +4,7 @@ import InputDefault from "./common/InputDefault";
 const AddPayInput = () => {
   return (
     <div>
-      <form className="flex flex-col gap-2 px-8 pt-3">
+      <form className="flex flex-col gap-2 pt-3">
         <InputDefault
           label="금액"
           type="number"

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -4,16 +4,18 @@ import React from "react";
 interface HeaderProps {
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
+  bgcolor?: string;
   title: string;
 }
 
 const Header: React.FC<HeaderProps> = ({
   leftIcon = <LucideChevronLeft size={24} />,
   title,
-  rightIcon = <div className="w-6 h-6" />, // h-6, w-6 → 24px
+  bgcolor = "bg-white",
+  rightIcon = <div className="h-6 w-6" />,
 }) => {
   return (
-    <div className="flex items-center justify-between h-16 px-3">
+    <div className={`flex h-16 items-center justify-between px-3 ${bgcolor}`}>
       {leftIcon}
       <p className="text-base font-medium">{title}</p>
       {rightIcon}

--- a/src/components/common/InputDefault.tsx
+++ b/src/components/common/InputDefault.tsx
@@ -18,13 +18,13 @@ const InputDefault: React.FC<PayInputProps> = ({
 
   return (
     <div className="h-15">
-      <div className="flex flex-col py-3 mb-5 border-b">
+      <div className="mb-5 flex flex-col border-b py-3 focus-within:border-pink-500">
         <div className="flex gap-5">
-          <label className="w-15"> {label} </label>
+          <label className="w-20"> {label} </label>
           <input
             type={inputType}
             placeholder={placeholder}
-            className="text-default"
+            className="text-default outline-none focus:outline-none focus:ring-0"
             onFocus={() => type === "date" && setInputType("date")} // 클릭하면 date로 변경
             onBlur={(e) =>
               type === "date" && !e.target.value && setInputType("text")

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { NAV_ITEMS } from "../../constants/NavItem";
 
-const Navbar = () => {
+interface NavbarProps {
+  bgcolor?: string;
+}
+
+const Navbar: React.FC<NavbarProps> = ({ bgcolor = "bg-white" }) => {
   return (
-    <div className="h-16 border-t border-lightest rounded-2xl">
-      <div className="flex items-center justify-between h-full px-5">
+    <div className="border-lightest h-16 rounded-2xl border-t">
+      <div
+        className={`${bgcolor} flex h-full items-center justify-between px-5`}
+      >
         {NAV_ITEMS.map(({ icon: Icon, label }, index) => (
           <div key={index} className="flex flex-col items-center">
             <Icon color="#aaa" strokeWidth={1.5} />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,13 +1,35 @@
 import React from "react";
+import { Outlet } from "react-router-dom";
 import Navbar from "../components/common/Navbar";
 import Header from "../components/common/Header";
 
-const MainLayout = (props: { children: React.ReactNode }) => {
+interface MainLayoutProps {
+  title: string;
+  bgColor?: string;
+}
+
+const MainLayout: React.FC<MainLayoutProps> = ({
+  title,
+  bgColor = "bg-white",
+}) => {
   return (
-    <div className="flex min-h-screen flex-col">
-      <Header title="지출 내역 추가" />
-      <main className="flex flex-grow flex-col">{props.children}</main>
-      <Navbar />
+    <div
+      className={`relative flex min-h-screen flex-col ${bgColor} box-border`}
+    >
+      {/* 헤더 (상단 고정) */}
+      <header className="fixed left-0 top-0 z-50 w-full">
+        <Header title={title} bgcolor={bgColor} />
+      </header>
+
+      {/* 메인 컨텐츠 (헤더 & 네브바 높이만큼 padding 적용) */}
+      <main className="flex w-full flex-grow justify-center px-6 py-16">
+        <Outlet /> {/* 자식 라우트가 렌더링될 위치 */}
+      </main>
+
+      {/* 네브바 (하단 고정) */}
+      <nav className="fixed bottom-0 left-0 z-50 w-full">
+        <Navbar bgcolor={bgColor} />
+      </nav>
     </div>
   );
 };

--- a/src/pages/AddPayPage.tsx
+++ b/src/pages/AddPayPage.tsx
@@ -5,16 +5,14 @@ import MainLayout from "../layouts/MainLayout";
 import SelectCategory from "../components/SelectCategory";
 import { SaveButton } from "../components/common/Buttons";
 
-const AddExpenditurePage = () => {
+const AddPayPage = () => {
   return (
-    <div className="flex flex-col">
-      <MainLayout>
-        <AddPayInput />
-        <SelectCategory />
-        <SaveButton title="저장하기" />
-      </MainLayout>
+    <div className="flex w-full flex-col">
+      <AddPayInput />
+      <SelectCategory />
+      <SaveButton title="저장하기" />
     </div>
   );
 };
 
-export default AddExpenditurePage;
+export default AddPayPage;

--- a/src/pages/BudgetManage.tsx
+++ b/src/pages/BudgetManage.tsx
@@ -4,10 +4,12 @@ import IconEvent from "../assets/categoryIcons/IconEvent";
 
 const BudgetManage = () => {
   return (
-    <div className="flex h-full flex-col bg-[#f8f8f8] px-6 py-5">
+    <div className="bg-second-bg flex h-full w-full flex-col">
+      {/*}
       <div className="flex h-16 w-full items-center justify-center">
         목표예산관리
       </div>
+      */}
       {/* 1. 목표예산 설정 */}
       <div className="1px mb-4 mt-5 flex items-center justify-between rounded-2xl border border-second-light bg-white px-4 py-3">
         <div>
@@ -53,7 +55,7 @@ const BudgetManage = () => {
         </div>
 
         {/* 예: 식비 카테고리 */}
-        <div className="mb-5 rounded-2xl bg-[#f8f8f8] px-2 py-2.5">
+        <div className="bg-second-bg mb-5 rounded-2xl px-2 py-2.5">
           <div className="mb-1 flex items-center justify-between pb-2">
             <div className="flex items-center space-x-2">
               <div className="flex rounded-full bg-second-lighter">
@@ -79,7 +81,7 @@ const BudgetManage = () => {
 
         {/* ////초과 예시 */}
 
-        <div className="mb-5 rounded-2xl bg-[#f8f8f8] px-2 py-2.5">
+        <div className="bg-second-bg mb-5 rounded-2xl px-2 py-2.5">
           <div className="mb-1 flex items-center justify-between pb-2">
             <div className="flex items-center space-x-2">
               <div className="flex rounded-full bg-second-lighter">
@@ -105,7 +107,7 @@ const BudgetManage = () => {
 
         {/*  */}
 
-        <div className="mb-5 rounded-2xl bg-[#f8f8f8] px-2 py-2.5">
+        <div className="bg-second-bg mb-5 rounded-2xl px-2 py-2.5">
           <div className="mb-1 flex items-center justify-between pb-2">
             <div className="flex items-center space-x-2">
               <div className="flex rounded-full bg-second-lighter">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,9 @@ module.exports = {
           light: "#D9D9D9",
           lighter: "#F4F4F5",
           lightest: "#EEEEEE,",
+          bg: "#F8F8F8",
         },
+
         // 마커들의 색상 DEFAULT -> border, light -> fill
         // 식비
         "marker-food": {


### PR DESCRIPTION
## #️⃣ 요약 설명

전체 프로젝트에 쓰이는 메인 레이아웃을 수정하였고, 관련된 코드들 대폭 수정함. 

## 📝 작업 내용

레이아웃 수정
- 헤더, 네브바 재사용 가능하게 수정 (타이틀, 색상 변경 가능) 상단, 하단 고정
- 전체 여백 적용 / 이외의 컴포넌트에 여백 있는거 간간히 수정함
- 레이아웃 재사용 가능하게 수정(색상 변경 가능)

라우터 방식 변경
 - 피드백 받은 스타일로 수정 (Outer 추가)

사용자 입력 (InputDefault.tsx)
- 포커스 스타일 변경


## 👀 이미지 첨부(선택)

<img width="567" alt="스크린샷 2025-02-26 오후 9 24 14" src="https://github.com/user-attachments/assets/3dda93e8-3c24-4bb9-b6a8-e638f23435c0" />

 포커스 변경 되었습니다.

## 💬 리뷰 요구사항

### 메인 레이아웃 사용 방법
<img width="588" alt="스크린샷 2025-02-26 오후 9 46 26" src="https://github.com/user-attachments/assets/1c995461-536f-4218-a987-5459d1f45ce5" />

- `title="페이지 제목"` → 헤더 제목 설정  
- `bgColor="bg-gray-100"` → 배경색 설정 (`Tailwind CSS` 적용 가능)  
- `<Outlet />` 위치에 페이지 컨텐츠가 렌더링됨  
- ** 레이아웃 안의 자식 컴포넌트는 `className="w-full"` 적용 필수!** 

### 헤더 세부 사항
<img width="572" alt="스크린샷 2025-02-26 오후 9 52 44" src="https://github.com/user-attachments/assets/1b173730-7109-4e12-b7c1-a53ade6ccf50" />

- `leftIcon` / `rightIcon` → 기본값 설정됨, 필요 시 커스텀 가능(Props로 아이콘 전달)

 

