### PR TITLE
[STYLE-15] 로그인/회원가입 페이지 퍼블리싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import BudgetManage from "./pages/BudgetManage";
 import MainLayout from "./layouts/MainLayout";
 import AddPayPage from "./pages/AddPayPage";
 import LoginPage from "./pages/LoginPage";
+import HeaderLayout from "./layouts/HeaderLayout";
+import SignupPage from "./pages/SignupPage";
 
 const App: React.FC = () => {
   return (
@@ -15,6 +17,9 @@ const App: React.FC = () => {
       </Route>
       <Route element={<MainLayout title="지출 내역 추가" />}>
         <Route path="/addpay" element={<AddPayPage />} />
+      </Route>
+      <Route element={<HeaderLayout />}>
+        <Route path="/signup" element={<SignupPage />} />
       </Route>
     </Routes>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,13 @@ import MainPage from "./pages/MainPage";
 import BudgetManage from "./pages/BudgetManage";
 import MainLayout from "./layouts/MainLayout";
 import AddPayPage from "./pages/AddPayPage";
+import LoginPage from "./pages/LoginPage";
 
 const App: React.FC = () => {
   return (
     <Routes>
       <Route path="/" element={<MainPage />} />
+      <Route path="/login" element={<LoginPage />} />
       <Route element={<MainLayout title="예산관리" bgColor="bg-second-bg" />}>
         <Route path="/budget" element={<BudgetManage />} />
       </Route>

--- a/src/components/common/Buttons.tsx
+++ b/src/components/common/Buttons.tsx
@@ -2,13 +2,16 @@ import React from "react";
 
 interface MainButtonProps {
   title: string;
+  style?: string;
 }
 
 // 저장하기 버튼 (TODO: onclick submit)
-export const SaveButton: React.FC<MainButtonProps> = ({ title }) => {
+export const SaveButton: React.FC<MainButtonProps> = ({ title, style }) => {
   return (
-    <div className="flex justify-center px-4">
-      <button className="flex items-center justify-center w-full h-12 my-5 text-lg font-medium text-white rounded-lg bg-main">
+    <div className="flex w-full justify-center">
+      <button
+        className={`my-5 flex h-12 w-full items-center justify-center rounded-lg bg-main text-lg font-medium text-white ${style}`}
+      >
         {title}
       </button>
     </div>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,5 +1,6 @@
 import { LucideChevronLeft } from "lucide-react";
 import React from "react";
+import { useMovePage } from "../../hooks/useMovePage";
 
 interface HeaderProps {
   leftIcon?: React.ReactNode;
@@ -14,9 +15,10 @@ const Header: React.FC<HeaderProps> = ({
   bgcolor = "bg-white",
   rightIcon = <div className="h-6 w-6" />,
 }) => {
+  const { moveToBack } = useMovePage();
   return (
     <div className={`flex h-16 items-center justify-between px-3 ${bgcolor}`}>
-      {leftIcon}
+      <div onClick={moveToBack}>{leftIcon}</div>
       <p className="text-base font-medium">{title}</p>
       {rightIcon}
     </div>

--- a/src/components/common/InputDefault.tsx
+++ b/src/components/common/InputDefault.tsx
@@ -4,13 +4,13 @@
 import React, { useState } from "react";
 
 interface PayInputProps {
-  label: string;
+  label?: string;
   type?: string;
   placeholder: string;
 }
 
 const InputDefault: React.FC<PayInputProps> = ({
-  label,
+  label = "",
   type = "text",
   placeholder,
 }) => {
@@ -20,7 +20,7 @@ const InputDefault: React.FC<PayInputProps> = ({
     <div className="h-15">
       <div className="mb-5 flex flex-col border-b py-3 focus-within:border-pink-500">
         <div className="flex gap-5">
-          <label className="w-20"> {label} </label>
+          {label && <label className="w-20"> {label} </label>}
           <input
             type={inputType}
             placeholder={placeholder}

--- a/src/components/common/InputDefault.tsx
+++ b/src/components/common/InputDefault.tsx
@@ -7,17 +7,19 @@ interface PayInputProps {
   label?: string;
   type?: string;
   placeholder: string;
+  style?: string;
 }
 
 const InputDefault: React.FC<PayInputProps> = ({
   label = "",
   type = "text",
   placeholder,
+  style = "",
 }) => {
   const [inputType, setInputType] = useState("type"); // 초기 상태를 저장
 
   return (
-    <div className="h-15">
+    <div className={`h-15 ${style}`}>
       <div className="mb-5 flex flex-col border-b py-3 focus-within:border-pink-500">
         <div className="flex gap-5">
           {label && <label className="w-20"> {label} </label>}

--- a/src/components/sections/PayTypeSection.tsx
+++ b/src/components/sections/PayTypeSection.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { payTypeList } from "../../constants/payType";
+
+const PayTypeSection: React.FC<{
+  selectedPayType: string;
+  setSelectedPayType: React.Dispatch<React.SetStateAction<string>>;
+}> = ({ selectedPayType, setSelectedPayType }) => {
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {payTypeList.map((payType) => (
+        <div
+          key={payType.type}
+          className={`flex flex-col items-center justify-center gap-2 rounded-md border py-4 ${selectedPayType === payType.type ? "border-main" : "border-second"}`}
+          onClick={() => setSelectedPayType(payType.type)}
+        >
+          {payType.icon({ size: 40 })}
+          <div className="font-bold">{payType.type}</div>
+          <div className="text-xs">{payType.discription}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PayTypeSection;

--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,7 @@ body,
   margin: 0 auto;
   max-width: 500px;
   position: relative;
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 @layer base {

--- a/src/layouts/HeaderLayout.tsx
+++ b/src/layouts/HeaderLayout.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import Header from "../components/common/Header";
+import { Outlet } from "react-router-dom";
+
+const HeaderLayout = () => {
+  return (
+    <>
+      <header className="fixed left-0 top-0 z-50 w-full">
+        <Header title="회원가입" />
+      </header>
+
+      <Outlet />
+    </>
+  );
+};
+
+export default HeaderLayout;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import IconNoPayType from "../assets/payTypeIcons/IconNoPayType";
+import InputDefault from "../components/common/InputDefault";
+import { SaveButton } from "../components/common/Buttons";
+
+const Logo = () => {
+  return (
+    <div className="flex items-center justify-start gap-5 py-14">
+      <IconNoPayType />
+      <div className="text-3xl font-bold text-main">PayRoad</div>
+    </div>
+  );
+};
+
+const Inputs = () => {
+  return (
+    <div className="flex flex-col">
+      <InputDefault placeholder="이메일" />
+      <InputDefault placeholder="비밀번호" />
+    </div>
+  );
+};
+
+const LoginAndSignUp = () => {
+  return (
+    <div>
+      <SaveButton title="로그인" style="mt-0 " />
+      <div className="flex items-center justify-center gap-2">
+        회원이 아니신가요?{" "}
+        <span className="text-second underline underline-offset-2">
+          회원가입
+        </span>
+      </div>
+    </div>
+  );
+};
+
+const LoginPage = () => {
+  return (
+    <div className="flex flex-col gap-10 px-6 py-10">
+      <Logo />
+      <Inputs />
+      <LoginAndSignUp />
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import IconNoPayType from "../assets/payTypeIcons/IconNoPayType";
 import InputDefault from "../components/common/InputDefault";
 import { SaveButton } from "../components/common/Buttons";
+import { useMovePage } from "../hooks/useMovePage";
 
 const Logo = () => {
   return (
@@ -22,12 +23,16 @@ const Inputs = () => {
 };
 
 const LoginAndSignUp = () => {
+  const { moveToPage } = useMovePage();
   return (
     <div>
       <SaveButton title="로그인" style="mt-0 " />
       <div className="flex items-center justify-center gap-2">
         회원이 아니신가요?{" "}
-        <span className="text-second underline underline-offset-2">
+        <span
+          onClick={() => moveToPage("/signup")}
+          className="text-second underline underline-offset-2"
+        >
           회원가입
         </span>
       </div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -3,7 +3,6 @@ import { CustomOverlayMap, Map } from "react-kakao-maps-sdk";
 import MapHeader from "../components/MapHeader";
 import IconMyLocation from "../assets/IconMyLocation";
 import { LucidePlus } from "lucide-react";
-import "../assets/bubble.css";
 import MapBubble from "../components/MapBubble";
 import { useMovePage } from "../hooks/useMovePage";
 import useGetMyCurrentLocation from "../hooks/useGetMyCurrentLocation";
@@ -15,7 +14,7 @@ const IconMoveMyLocation: React.FC<{ moveToCurrentLocation: () => void }> = ({
   return (
     <div
       onClick={moveToCurrentLocation}
-      className="z-10 grid w-10 bg-white rounded-full aspect-square place-items-center drop-shadow-50"
+      className="z-10 grid aspect-square w-10 place-items-center rounded-full bg-white drop-shadow-50"
     >
       <IconMyLocation />
     </div>
@@ -26,7 +25,7 @@ const IconFastInputPay: React.FC = () => {
   return (
     <div
       onClick={() => moveToPage("/addpay")}
-      className="z-10 grid rounded-full aspect-square w-11 place-items-center bg-main drop-shadow-50"
+      className="z-10 grid aspect-square w-11 place-items-center rounded-full bg-main drop-shadow-50"
     >
       <LucidePlus size={24} color="#FFF" />
     </div>
@@ -41,8 +40,8 @@ const MyCurrentLocation: React.FC<{
       position={{ lat: location.lat, lng: location.lng }}
       zIndex={1}
     >
-      <div className="grid w-8 rounded-full aspect-square place-items-center bg-main bg-opacity-30">
-        <div className="w-4 border-2 border-white rounded-full aspect-square bg-main"></div>
+      <div className="grid aspect-square w-8 place-items-center rounded-full bg-main bg-opacity-30">
+        <div className="aspect-square w-4 rounded-full border-2 border-white bg-main"></div>
       </div>
     </CustomOverlayMap>
   );
@@ -121,7 +120,7 @@ const MainPage: React.FC = () => {
           ),
         )}
       </Map>
-      <div className="flex flex-col justify-between w-full h-full px-6 pt-10 pb-5">
+      <div className="flex h-full w-full flex-col justify-between px-6 pb-5 pt-10">
         <MapHeader />
         <div className="flex items-end justify-between">
           <IconMoveMyLocation moveToCurrentLocation={moveToCurrentLocation} />

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -34,6 +34,7 @@ const AgeGroup: React.FC<{
       <div className="z-10 flex min-w-[calc(100vw-24px)] gap-3 overflow-x-scroll pr-6">
         {ageGroups.map((age) => (
           <div
+            key={age}
             onClick={() => {
               setSelectedAge(age);
             }}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import InputDefault from "../components/common/InputDefault";
+import { payTypeList } from "../constants/payType";
+import PayTypeSection from "../components/sections/PayTypeSection";
+import { SaveButton } from "../components/common/Buttons";
+
+const SignupInputs = () => {
+  return (
+    <>
+      <InputDefault placeholder="이메일" />
+      <div className="flex w-full items-end gap-3">
+        <InputDefault placeholder="이메일 인증번호" style="w-full" />
+        <div className="mb-5 grid h-10 w-16 shrink-0 place-items-center gap-3 rounded-lg bg-second-light font-medium text-white">
+          확인
+        </div>
+      </div>
+      <InputDefault placeholder="비밀번호" />
+      <InputDefault placeholder="비밀번호 확인" />
+      <InputDefault placeholder="닉네임" />
+      <InputDefault placeholder="집 정보 입력" />
+    </>
+  );
+};
+
+const AgeGroup: React.FC<{
+  selectedAge: string;
+  setSelectedAge: React.Dispatch<React.SetStateAction<string>>;
+}> = ({ selectedAge, setSelectedAge }) => {
+  const ageGroups = ["10대", "20대", "30대", "40대", "50대~"];
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-sm">연령대</div>
+      <div className="z-10 flex min-w-[calc(100vw-24px)] gap-3 overflow-x-scroll pr-6">
+        {ageGroups.map((age) => (
+          <div
+            onClick={() => {
+              setSelectedAge(age);
+            }}
+            className={`${selectedAge === age ? "border-main text-main" : "border-second text-second"} shrink-0 rounded-full border px-5 py-2`}
+          >
+            {age}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const SelectPayType: React.FC<{
+  selectedPayType: string;
+  setSelectedPayType: React.Dispatch<React.SetStateAction<string>>;
+}> = ({ selectedPayType, setSelectedPayType }) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-sm">소비성향 설정</div>
+      <div className="text-sm text-second">
+        자신의 소비패턴과 가장 잘 맞는 유형을 선택하세요.
+      </div>
+      <PayTypeSection
+        selectedPayType={selectedPayType}
+        setSelectedPayType={setSelectedPayType}
+      />
+    </div>
+  );
+};
+
+const SignupPage = () => {
+  const [selectedAge, setSelectedAge] = useState<string>("");
+  const [selectedPayType, setSelectedPayType] = useState<string>("");
+
+  return (
+    <div className="flex flex-col gap-5 px-6 py-5 pt-16">
+      <SignupInputs />
+      <AgeGroup selectedAge={selectedAge} setSelectedAge={setSelectedAge} />
+      <SelectPayType
+        selectedPayType={selectedPayType}
+        setSelectedPayType={setSelectedPayType}
+      />
+      <SaveButton title="회원가입" />
+    </div>
+  );
+};
+
+export default SignupPage;


### PR DESCRIPTION
## #️⃣ 요약 설명
로그인/회원가입 페이지 퍼블리싱

## 📝 작업 내용
- 로그인/회원가입 페이지 퍼블리싱
- 헤더 뒤로가기 버튼 클릭 기능 구현
```javascript
const PayTypeSection: React.FC<{
  selectedPayType: string;
  setSelectedPayType: React.Dispatch<React.SetStateAction<string>>;
}> = ({ selectedPayType, setSelectedPayType }) => {
  return (
    <div className="grid grid-cols-2 gap-2">
      {payTypeList.map((payType) => (
        <div
          key={payType.type}
          className={`flex flex-col items-center justify-center gap-2 rounded-md border py-4 ${selectedPayType === payType.type ? "border-main" : "border-second"}`}
          onClick={() => setSelectedPayType(payType.type)}
        >
          {payType.icon({ size: 40 })}
          <div className="font-bold">{payType.type}</div>
          <div className="text-xs">{payType.discription}</div>
        </div>
      ))}
    </div>
  );
};
```
payType 선택하는 컴포넌트 생성
props로 선택된 값, 선택된 값 변경 함수 넘겨줘야 함

## 💻 동작 확인
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e6bcfb94-ffd0-4b3e-a3fb-45be741b1c68" />
회원가입 클릭하면 회원가입 페이지로 이동
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f1f0e96e-9ca2-4562-ad0a-e08bb4f8be2d" />
연령대, 소비성향 선택되면 border 색상 변경


## 👀 이미지 첨부(선택)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/63b34a55-28e8-47f3-a00d-50366ac471db" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0defcab1-dcb5-4456-8deb-d5208d04ed8a" />


## 💬 리뷰 요구사항(선택)

index.css에 oveflow: hidden; -> overflow-x: hidden;으로 변경해뒀습니당