### PR TITLE
[STYLE-31] 지도 정보 띄우기 및 아이콘 리스트 변경

### DIFF
--- a/src/components/MapBubble.tsx
+++ b/src/components/MapBubble.tsx
@@ -1,47 +1,69 @@
 import React, { useEffect, useRef } from "react";
 import { CustomOverlayMap } from "react-kakao-maps-sdk";
-import "../assets/css/bubble.css";
 import { findCategory } from "../utils/findTypeOrCategory";
 import { formatPrice } from "../utils/formatPrice";
+import IconMapMarker from "../assets/IconMapMarker";
+import "../assets/css/bubble.css";
 
-const MapBubble: React.FC<{
+interface MapMarkerProps {
+  type: "icon" | "bubble"; // 마커 종류 지정
   position: { lat: number; lng: number };
   category: string;
-  price: number;
-  count: number;
-}> = ({ position, category, price, count }) => {
-  const bubbleCategory = findCategory(category);
+  price?: number;
+  count?: number;
+  onClick?: () => void;
+}
+
+const MapMarker: React.FC<MapMarkerProps> = ({
+  type,
+  position,
+  category,
+  price,
+  count,
+  onClick,
+}) => {
+  const categoryData = findCategory(category);
   const bubbleRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (bubbleRef.current) {
+    if (bubbleRef.current && type === "bubble") {
       const el = bubbleRef.current;
-      el.style.setProperty("--border-color", bubbleCategory?.border ?? "");
+      el.style.setProperty("--border-color", categoryData?.border ?? "");
       el.style.setProperty(
         "--background-color",
-        bubbleCategory?.background ?? "",
+        categoryData?.background ?? "",
       );
     }
-  }, [bubbleCategory]);
+  }, [categoryData, type]);
 
   return (
     <CustomOverlayMap position={position}>
-      <div
-        ref={bubbleRef}
-        style={{
-          backgroundColor: bubbleCategory?.background,
-          borderColor: bubbleCategory?.border,
-        }}
-        className={`bubble flex items-end gap-1 border text-sm`}
-      >
-        {bubbleCategory?.icon && bubbleCategory.icon({})}
-        <div>
-          ₩{formatPrice(price)}
-          <span className="text-[10px]">({count})</span>
+      {type === "icon" ? (
+        <div className="relative" onClick={onClick}>
+          <IconMapMarker color={categoryData?.border || ""} />
+          <div className="absolute left-[7px] top-2">
+            {categoryData?.icon({ color: "white" })}
+          </div>
         </div>
-      </div>
+      ) : (
+        <div
+          onClick={onClick}
+          ref={bubbleRef}
+          style={{
+            backgroundColor: categoryData?.background,
+            borderColor: categoryData?.border,
+          }}
+          className="flex items-end gap-1 text-sm border bubble"
+        >
+          {categoryData?.icon && categoryData.icon({})}
+          <div>
+            ₩{formatPrice(price || 0)}
+            <span className="text-[10px]">({count})</span>
+          </div>
+        </div>
+      )}
     </CustomOverlayMap>
   );
 };
 
-export default MapBubble;
+export default MapMarker;

--- a/src/components/MapBubble.tsx
+++ b/src/components/MapBubble.tsx
@@ -34,7 +34,7 @@ const MapBubble: React.FC<{
         }}
         className={`bubble flex items-end gap-1 border text-sm`}
       >
-        {bubbleCategory?.icon}
+        {bubbleCategory?.icon && bubbleCategory.icon({})}
         <div>
           ₩{formatPrice(price)}
           <span className="text-[10px]">({count})</span>

--- a/src/components/MapHeader.tsx
+++ b/src/components/MapHeader.tsx
@@ -24,7 +24,7 @@ const Category: React.FC<
       }}
       className={`flex w-fit flex-shrink-0 items-center gap-1 rounded-full border bg-white px-2.5 py-2 font-medium drop-shadow-10 ${selectedCategory === text ? "border-main" : "border-white"}`}
     >
-      {icon}
+      {icon({})}
       <div>{text}</div>
     </div>
   );
@@ -82,7 +82,7 @@ const DropDown: React.FC<DropDownProps> = ({ isOpen, setIsOpen }) => {
           <div
             key={type.type}
             onClick={() => setType(type)}
-            className="flex gap-1 border-b border-b-second py-2 last:border-none"
+            className="flex gap-1 py-2 border-b border-b-second last:border-none"
           >
             {type.icon({ size: 20 })}
             {type.type}
@@ -117,7 +117,7 @@ const MyProperty: React.FC<{ name: string; property: string }> = ({
 const MapHeader: React.FC = () => {
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
   return (
-    <div className="z-10 flex max-w-full flex-col">
+    <div className="z-10 flex flex-col max-w-full">
       <CategoryList />
       <div className="flex items-center justify-between py-1">
         <MyProperty name="희연" property="플렉스" />

--- a/src/components/MapIconMarker.tsx
+++ b/src/components/MapIconMarker.tsx
@@ -14,10 +14,7 @@ const MapIconMarker: React.FC<{
     <CustomOverlayMap position={position}>
       <IconMapMarker color={markerCategory?.border || ""} />
       <div className="absolute left-[7px] top-2">
-        {React.isValidElement(markerCategory?.icon) &&
-          React.cloneElement(markerCategory.icon as React.ReactElement<any>, {
-            color: "white",
-          })}
+        {markerCategory?.icon({ color: "white" })}
       </div>
     </CustomOverlayMap>
   );

--- a/src/components/PayList.tsx
+++ b/src/components/PayList.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { spendingData } from "../spendingData";
-import IconTraffic from "../assets/categoryIcons/IconTraffic";
-import IconFood from "../assets/categoryIcons/IconFood";
 import { categoryList } from "../constants/category";
 
 // 아이콘 가져오기 ( {<IconFood/>} 이런식으로 반환됨)
@@ -20,23 +18,19 @@ const formatDateWithWeekday = (year: string, month: string, day: string) => {
 const PayDay: React.FC<{ data: any }> = ({ data }) => {
   const categoryIcon = getIcon(data.category);
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex flex-col w-full">
       <div className="flex flex-row items-center">
         {/* 카테고리 아이콘 */}
-        <div className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-second-lighter">
-          {React.isValidElement(categoryIcon?.icon) &&
-            React.cloneElement(categoryIcon.icon as React.ReactElement<any>, {
-              size: "24",
-            })}
+        <div className="flex items-center justify-center flex-none w-10 h-10 rounded-full bg-second-lighter">
+          {categoryIcon?.icon({ size: 24 })}
         </div>
-
         {/* 지출 내용 */}
-        <div className="flex max-w-44 flex-grow flex-col gap-1 p-3">
+        <div className="flex flex-col flex-grow gap-1 p-3 max-w-44">
           <p className="text-sm"> {data.details} </p>
           <p className="text-xs text-second"> {data.point_name} </p>
         </div>
         {/* 지출 금액 */}
-        <p className="ml-auto text-right text-base font-medium text-main">
+        <p className="ml-auto text-base font-medium text-right text-main">
           {data.price.toLocaleString()}원
         </p>
       </div>
@@ -47,7 +41,7 @@ const PayDay: React.FC<{ data: any }> = ({ data }) => {
 // 전체 소비리스트
 const PayList = () => {
   return (
-    <div className="flex w-full flex-col px-6">
+    <div className="flex flex-col w-full px-6">
       {spendingData.records.map((dayData, index) => (
         <div key={dayData.day} className="mb-5">
           {/* 날짜 및 하루 총액 표시 */}

--- a/src/components/SelectCategory.tsx
+++ b/src/components/SelectCategory.tsx
@@ -1,9 +1,6 @@
-import { LucideArrowUpNarrowWide } from "lucide-react";
-import React, { useState } from "react";
+import React from "react";
 import { categoryList } from "../constants/category";
 import CategorySection from "./sections/CategorySection";
-
-//   <CategorySection icon={<IconFood size={28} />} name="식비" />
 
 interface CategoryProps {
   classname?: string;
@@ -22,7 +19,7 @@ const SelectCategory: React.FC<CategoryProps> = ({
       {categoryList.map((item) => (
         <CategorySection
           key={item.text}
-          icon={item.icon}
+          icon={item.icon({})}
           name={item.text}
           toggle={() => {
             setSelectName(item.text);

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -11,20 +11,20 @@ const Navbar: React.FC = () => {
   };
 
   return (
-    <nav className="border-lightest sticky inset-0 z-50 h-16 w-full rounded-2xl border-t">
-      <div className="flex h-full items-center justify-between bg-white px-5">
+    <nav className="sticky inset-0 z-50 h-16 w-full shrink-0 rounded-t-2xl border-t-[1px] border-t-second-lightest">
+      <div className="flex items-center justify-between h-full px-5 bg-white rounded-t-2xl">
         {NAV_ITEMS.map(({ icon: Icon, label, navId, url }, idx) => (
           <div
             onClick={() => handleClickNavbar(url)}
             key={navId}
-            className="flex flex-col items-center"
+            className="flex flex-col items-center gap-0.5"
           >
             <Icon
-              color={loctaion.pathname === url ? "#333" : "#aaa"}
+              color={loctaion.pathname === url ? "#666" : "#aaa"}
               strokeWidth={1.5}
             />
             <p
-              className={`text-xs text-second ${location.pathname === url ? "text-second-dark" : "text-second"}`}
+              className={`text-xs text-second ${location.pathname === url ? "text-[#666]" : "text-second"}`}
             >
               {label}
             </p>

--- a/src/components/maps/KakaoMap.tsx
+++ b/src/components/maps/KakaoMap.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import useMapInfo from "../../stores/mapInfo";
+import { Map } from "react-kakao-maps-sdk";
+
+const KakaoMap: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const { mapInfo, setLevel } = useMapInfo();
+  return (
+    <Map
+      center={{ lat: mapInfo.center.lat, lng: mapInfo.center.lng }}
+      style={{
+        width: "100%",
+        height: "100%",
+        position: "absolute",
+      }}
+      isPanto={true}
+      level={mapInfo.level}
+      ref={mapInfo.ref}
+      onZoomChanged={(map) => {
+        const level = map.getLevel();
+        setLevel(level);
+      }}
+    >
+      {children}
+    </Map>
+  );
+};
+
+export default KakaoMap;

--- a/src/components/maps/KakaoMap.tsx
+++ b/src/components/maps/KakaoMap.tsx
@@ -1,25 +1,31 @@
-import React from "react";
+import React, { useEffect } from "react";
 import useMapInfo from "../../stores/mapInfo";
 import { Map } from "react-kakao-maps-sdk";
 
 const KakaoMap: React.FC<{
   children: React.ReactNode;
 }> = ({ children }) => {
-  const { mapInfo, setLevel } = useMapInfo();
+  const { level, myLocation, mapRef, setLevel } = useMapInfo();
+
+  useEffect(() => {}, []);
   return (
     <Map
-      center={{ lat: mapInfo.center.lat, lng: mapInfo.center.lng }}
+      center={{ lat: myLocation.lat, lng: myLocation.lng }}
       style={{
         width: "100%",
         height: "100%",
         position: "absolute",
       }}
       isPanto={true}
-      level={mapInfo.level}
-      ref={mapInfo.ref}
+      level={level}
+      ref={mapRef}
       onZoomChanged={(map) => {
         const level = map.getLevel();
         setLevel(level);
+      }}
+      onCenterChanged={(map) => {
+        const lat = map.getCenter().getLat();
+        const lng = map.getCenter().getLng();
       }}
     >
       {children}

--- a/src/components/maps/MapBottom.tsx
+++ b/src/components/maps/MapBottom.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from "react";
 import IconMyLocation from "../../assets/IconMyLocation";
 import { LucidePlus } from "lucide-react";
 import { useMovePage } from "../../hooks/useMovePage";
@@ -65,26 +65,21 @@ const ShowDetailInfo: React.FC<{
 };
 
 const MapBottom: React.FC<{
-  location: {
-    lat: number;
-    lng: number;
-  };
   selectedData?: DataProps;
   categoryInfo?: CategoryProps;
   showBubble: boolean;
   setShowBubble: React.Dispatch<React.SetStateAction<boolean>>;
-}> = ({ location, selectedData, categoryInfo, showBubble, setShowBubble }) => {
+}> = ({ selectedData, categoryInfo, showBubble, setShowBubble }) => {
   const showBubbleRef = useRef<HTMLDivElement>(null!);
   useClickOutside(showBubbleRef, () => setShowBubble(false));
 
-  const { setCenter, mapInfo } = useMapInfo();
+  const { mapRef, myLocation } = useMapInfo();
   const moveToCurrentLocation = () => {
-    if (mapInfo.ref.current) {
-      mapInfo.ref.current.panTo(
-        new kakao.maps.LatLng(location.lat, location.lng),
+    if (mapRef.current) {
+      mapRef.current.panTo(
+        new kakao.maps.LatLng(myLocation.lat, myLocation.lng),
       );
     }
-    setCenter({ lat: location.lat, lng: location.lng });
   };
   return (
     <>

--- a/src/components/maps/MapBottom.tsx
+++ b/src/components/maps/MapBottom.tsx
@@ -1,0 +1,108 @@
+import React, { useRef, useState } from "react";
+import IconMyLocation from "../../assets/IconMyLocation";
+import { LucidePlus } from "lucide-react";
+import { useMovePage } from "../../hooks/useMovePage";
+import { CategoryProps } from "../../constants/category";
+import { formatPrice } from "../../utils/formatPrice";
+import useMapInfo from "../../stores/mapInfo";
+import useClickOutside from "../../hooks/useClickOutside";
+
+const IconMoveMyLocation: React.FC<{ moveToCurrentLocation: () => void }> = ({
+  moveToCurrentLocation,
+}) => {
+  return (
+    <div
+      onClick={moveToCurrentLocation}
+      className="z-10 grid w-10 bg-white rounded-full aspect-square place-items-center drop-shadow-50"
+    >
+      <IconMyLocation />
+    </div>
+  );
+};
+const IconFastInputPay: React.FC = () => {
+  const { moveToPage } = useMovePage();
+  return (
+    <div
+      onClick={() => moveToPage("/addpay")}
+      className="z-10 grid rounded-full aspect-square w-11 place-items-center bg-main drop-shadow-50"
+    >
+      <LucidePlus size={24} color="#FFF" />
+    </div>
+  );
+};
+
+interface DataProps {
+  category: string;
+  price: number;
+  count: number;
+  detail: string;
+  place: string;
+}
+
+const ShowDetailInfo: React.FC<{
+  showBubbleRef: React.RefObject<HTMLDivElement>;
+  selectedData: DataProps;
+  categoryInfo: CategoryProps;
+}> = ({ showBubbleRef, selectedData, categoryInfo }) => {
+  return (
+    <div
+      ref={showBubbleRef}
+      className="flex flex-col gap-2 p-3 bg-white rounded-lg drop-shadow-10"
+    >
+      <div className="flex items-center justify-between">
+        {selectedData!.place}
+        <div
+          className={`flex items-center gap-1 rounded-lg border px-1.5 py-1 ${categoryInfo?.bgColor} ${categoryInfo?.borderColor}`}
+        >
+          <div>{categoryInfo?.icon({ size: 16 })}</div>
+          <div className="text-sm">{selectedData!.category}</div>
+        </div>
+      </div>
+      <div className="text-xs font-light">{selectedData!.detail}</div>
+      <div className="text-right">{formatPrice(selectedData!.price)}원</div>
+    </div>
+  );
+};
+
+const MapBottom: React.FC<{
+  location: {
+    lat: number;
+    lng: number;
+  };
+  selectedData?: DataProps;
+  categoryInfo?: CategoryProps;
+  showBubble: boolean;
+  setShowBubble: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({ location, selectedData, categoryInfo, showBubble, setShowBubble }) => {
+  const showBubbleRef = useRef<HTMLDivElement>(null!);
+  useClickOutside(showBubbleRef, () => setShowBubble(false));
+
+  const { setCenter, mapInfo } = useMapInfo();
+  const moveToCurrentLocation = () => {
+    if (mapInfo.ref.current) {
+      mapInfo.ref.current.panTo(
+        new kakao.maps.LatLng(location.lat, location.lng),
+      );
+    }
+    setCenter({ lat: location.lat, lng: location.lng });
+  };
+  return (
+    <>
+      <div className="z-10 flex flex-col gap-3">
+        <div className="flex items-end justify-between">
+          <IconMoveMyLocation moveToCurrentLocation={moveToCurrentLocation} />
+          <IconFastInputPay />
+        </div>
+        {showBubble && (
+          <ShowDetailInfo
+            showBubbleRef={showBubbleRef}
+            selectedData={selectedData!}
+            categoryInfo={categoryInfo!}
+          />
+        )}
+      </div>
+    </>
+  );
+};
+
+export default MapBottom;

--- a/src/components/maps/MapHeader.tsx
+++ b/src/components/maps/MapHeader.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
-import { categoryList, CategoryProps } from "../constants/category";
+import { categoryList, CategoryProps } from "../../constants/category";
 import { ChevronDown } from "lucide-react";
-import useClickOutside from "../hooks/useClickOutside";
-import { payTypeList, PayTypeProps } from "../constants/payType";
-import useUserInfo from "../stores/userInfo";
-import { findType } from "../utils/findTypeOrCategory";
+import useClickOutside from "../../hooks/useClickOutside";
+import { payTypeList, PayTypeProps } from "../../constants/payType";
+import useUserInfo from "../../stores/userInfo";
+import { findType } from "../../utils/findTypeOrCategory";
 
 const Category: React.FC<
   CategoryProps & {

--- a/src/constants/category.tsx
+++ b/src/constants/category.tsx
@@ -11,28 +11,25 @@ import IconSaving from "../assets/categoryIcons/IconSaving";
 import IconEvent from "../assets/categoryIcons/IconEvent";
 import IconEtc from "../assets/categoryIcons/IconEtc";
 
-export type CategoryProps = {
-  text: string;
-  // 테일윈드에서 사용
-  borderColor?: string;
-  bgColor?: string;
-  icon?: ReactNode;
-  // inline-style에서 사용
-  border?: string;
-  background?: string;
-};
-
 export interface IconProps {
   color?: "white";
   size?: number; // 아이콘 크기 조정
 }
+export type CategoryProps = {
+  text: string;
+  borderColor?: string;
+  bgColor?: string;
+  icon: (props: IconProps) => ReactNode; // IconProps를 적용
+  border?: string;
+  background?: string;
+};
 
 export const categoryList: CategoryProps[] = [
   {
     text: "식비",
     borderColor: "border-marker-food",
     bgColor: "bg-marker-food-light",
-    icon: <IconFood />,
+    icon: (props: { size?: number }) => <IconFood {...props} />,
     border: "#AAD6FF",
     background: "#E9F1F8",
   },
@@ -40,7 +37,7 @@ export const categoryList: CategoryProps[] = [
     text: "주거",
     borderColor: "border-marker-home",
     bgColor: "bg-marker-home-light",
-    icon: <IconHome />,
+    icon: (props: { size?: number }) => <IconHome {...props} />,
     border: "#007FF2",
     background: "#CCE5FC",
   },
@@ -48,7 +45,7 @@ export const categoryList: CategoryProps[] = [
     text: "교통",
     borderColor: "border-marker-traffic",
     bgColor: "bg-marker-traffic-light",
-    icon: <IconTraffic />,
+    icon: (props: { size?: number }) => <IconTraffic {...props} />,
     border: "#2D67D5",
     background: "#D5E1F7",
   },
@@ -56,7 +53,7 @@ export const categoryList: CategoryProps[] = [
     text: "통신",
     borderColor: "border-marker-com",
     bgColor: "bg-marker-com-light",
-    icon: <IconCom />,
+    icon: (props: { size?: number }) => <IconCom {...props} />,
     border: "#23B169",
     background: "#D3EFE1",
   },
@@ -64,7 +61,7 @@ export const categoryList: CategoryProps[] = [
     text: "건강",
     borderColor: "border-marker-health",
     bgColor: "bg-marker-health-light",
-    icon: <IconHealth />,
+    icon: (props: { size?: number }) => <IconHealth {...props} />,
     border: "#77CEBD",
     background: "#E4F5F2",
   },
@@ -72,7 +69,7 @@ export const categoryList: CategoryProps[] = [
     text: "쇼핑",
     borderColor: "border-marker-shopping",
     bgColor: "bg-marker-shopping-light",
-    icon: <IconShopping />,
+    icon: (props: { size?: number }) => <IconShopping {...props} />,
     border: "#EF4452",
     background: "#FCDADC",
   },
@@ -80,7 +77,7 @@ export const categoryList: CategoryProps[] = [
     text: "교육",
     borderColor: "border-marker-education",
     bgColor: "bg-marker-education-light",
-    icon: <IconEducation />,
+    icon: (props: { size?: number }) => <IconEducation {...props} />,
     border: "#FD9F2C",
     background: "#FFECD5",
   },
@@ -88,7 +85,7 @@ export const categoryList: CategoryProps[] = [
     text: "문화생활",
     borderColor: "border-marker-hobby",
     bgColor: "bg-marker-hobby-light",
-    icon: <IconHobby />,
+    icon: (props: { size?: number }) => <IconHobby {...props} />,
     border: "#A064FF",
     background: "#ECE0FF",
   },
@@ -96,7 +93,7 @@ export const categoryList: CategoryProps[] = [
     text: "저축",
     borderColor: "border-marker-saving",
     bgColor: "bg-marker-saving-light",
-    icon: <IconSaving />,
+    icon: (props: { size?: number }) => <IconSaving {...props} />,
     border: "#FFC522",
     background: "#FFF3D3",
   },
@@ -104,7 +101,7 @@ export const categoryList: CategoryProps[] = [
     text: "경조사",
     borderColor: "border-marker-event",
     bgColor: "bg-marker-event-light",
-    icon: <IconEvent />,
+    icon: (props: { size?: number }) => <IconEvent {...props} />,
     border: "#BFBFBF",
     background: "#F2F2F2",
   },
@@ -112,7 +109,7 @@ export const categoryList: CategoryProps[] = [
     text: "기타",
     borderColor: "border-marker-etc",
     bgColor: "bg-marker-etc-light",
-    icon: <IconEtc />,
+    icon: (props: { size?: number }) => <IconEtc {...props} />,
     border: "#86584A",
     background: "#E7DEDB",
   },

--- a/src/hooks/useGetMyCurrentLocation.ts
+++ b/src/hooks/useGetMyCurrentLocation.ts
@@ -1,12 +1,12 @@
 import { useEffect } from "react";
 
 const useGetMyCurrentLocation = (
-  setLocation: (location: { lat: number; lng: number }) => void,
+  setMyLocation: (location: { lat: number; lng: number }) => void,
   setMapCenter: (mapCenter: { lat: number; lng: number }) => void,
 ) => {
   const handleSuccess = (pos: GeolocationPosition) => {
     const { latitude, longitude } = pos.coords;
-    setLocation({ lat: latitude, lng: longitude });
+    setMyLocation({ lat: latitude, lng: longitude });
     setMapCenter({ lat: latitude, lng: longitude });
     console.log(latitude, longitude);
   };
@@ -14,6 +14,7 @@ const useGetMyCurrentLocation = (
   const handleError = (error: GeolocationPositionError) => {
     console.error("위치 정보 가져오기 실패");
   };
+
   useEffect(() => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(handleSuccess, handleError);

--- a/src/layouts/NavBarLayout.tsx
+++ b/src/layouts/NavBarLayout.tsx
@@ -4,10 +4,10 @@ import Navbar from "../components/common/Navbar";
 
 const NavBarLayout = () => {
   return (
-    <>
+    <div className="relative flex flex-col h-full">
       <Outlet />
       <Navbar />
-    </>
+    </div>
   );
 };
 

--- a/src/pages/BudgetManageSet.tsx
+++ b/src/pages/BudgetManageSet.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import IconFood from "../assets/categoryIcons/IconFood";
 import { SaveButton } from "../components/common/Buttons";
 import { categoryList } from "../constants/category";
 
@@ -68,7 +67,7 @@ const MonthlyBudgetSet: React.FC<{
           <span className="text-sm font-bold text-[#006f6f]">
             {" " + Math.round(monthBudget / 30).toLocaleString()}원{" "}
           </span>
-           소비가 가능해요.
+          소비가 가능해요.
         </div>
       </div>
     </div>
@@ -105,7 +104,7 @@ const MonthlyBudgetBar: React.FC<{
               <div className="flex items-center justify-between pb-2 mb-1">
                 <div className="z-20 flex items-center space-x-2">
                   <div className="flex rounded-full bg-second-lighter">
-                    {cat.icon}
+                    {cat.icon({})}
                   </div>
                   <div className="text-sm font-medium shrink-0">{cat.text}</div>
                   {/* 퍼센티지 표시 (소수점 반올림) */}
@@ -197,7 +196,7 @@ const BudgetManageSet: React.FC = () => {
               남은예산
               <div>
                 {remain < 0 ? (
-                  <div className="flex flex-col items-end m-0 text-base font-bold text-main tb-0">
+                  <div className="flex flex-col items-end m-0 text-base font-bold tb-0 text-main">
                     {remain.toLocaleString()}원
                   </div>
                 ) : (
@@ -217,10 +216,13 @@ const BudgetManageSet: React.FC = () => {
           />
         </div>
       </div>
-      <SaveButton 
-  title={remain >= 0 ? `남은 금액: ${remain.toLocaleString()}원` : `예산 초과: ${Math.abs(remain).toLocaleString()}원`} 
-/>
-
+      <SaveButton
+        title={
+          remain >= 0
+            ? `남은 금액: ${remain.toLocaleString()}원`
+            : `예산 초과: ${Math.abs(remain).toLocaleString()}원`
+        }
+      />
     </div>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,39 +1,13 @@
-import React, { useEffect, useRef, useState } from "react";
-import { CustomOverlayMap, Map } from "react-kakao-maps-sdk";
-import MapHeader from "../components/MapHeader";
-import IconMyLocation from "../assets/IconMyLocation";
-import { LucidePlus } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import { CustomOverlayMap } from "react-kakao-maps-sdk";
+import MapHeader from "../components/maps/MapHeader";
 import MapBubble from "../components/MapBubble";
-import { useMovePage } from "../hooks/useMovePage";
 import useGetMyCurrentLocation from "../hooks/useGetMyCurrentLocation";
-import { formatPrice } from "../utils/formatPrice";
 import { findCategory } from "../utils/findTypeOrCategory";
 import { CategoryProps } from "../constants/category";
-import useClickOutside from "../hooks/useClickOutside";
-
-const IconMoveMyLocation: React.FC<{ moveToCurrentLocation: () => void }> = ({
-  moveToCurrentLocation,
-}) => {
-  return (
-    <div
-      onClick={moveToCurrentLocation}
-      className="z-10 grid w-10 bg-white rounded-full aspect-square place-items-center drop-shadow-50"
-    >
-      <IconMyLocation />
-    </div>
-  );
-};
-const IconFastInputPay: React.FC = () => {
-  const { moveToPage } = useMovePage();
-  return (
-    <div
-      onClick={() => moveToPage("/addpay")}
-      className="z-10 grid rounded-full aspect-square w-11 place-items-center bg-main drop-shadow-50"
-    >
-      <LucidePlus size={24} color="#FFF" />
-    </div>
-  );
-};
+import useMapInfo from "../stores/mapInfo";
+import KakaoMap from "../components/maps/KakaoMap";
+import MapBottom from "../components/maps/MapBottom";
 
 const MyCurrentLocation: React.FC<{
   location: { lat: number; lng: number };
@@ -49,29 +23,22 @@ const MyCurrentLocation: React.FC<{
   );
 };
 
+interface DataProps {
+  category: string;
+  price: number;
+  count: number;
+  detail: string;
+  place: string;
+}
+
 const MainPage: React.FC = () => {
   const [location, setLocation] = useState({ lat: 0, lng: 0 });
-  const [level, setLevel] = useState(3);
-  const [mapCenter, setMapCenter] = useState({ lat: 0, lng: 0 });
-  const mapRef = useRef<kakao.maps.Map | null>(null);
+  const { mapInfo, setCenter } = useMapInfo();
+  const [showBubble, setShowBubble] = useState<boolean>(false);
+  const [selectedData, setSelectedBubble] = useState<DataProps>();
+  const [categoryInfo, setCategoryInfo] = useState<CategoryProps>();
 
-  useGetMyCurrentLocation(setLocation, setMapCenter);
-
-  const moveToCurrentLocation = () => {
-    if (mapRef.current) {
-      mapRef.current.panTo(new kakao.maps.LatLng(location.lat, location.lng));
-    }
-    setMapCenter({ lat: location.lat, lng: location.lng });
-  };
-
-  interface DataProps {
-    category: string;
-    price: number;
-    count: number;
-    detail: string;
-    place: string;
-  }
-
+  // TODO : remove dummy datas
   const dummyDatas = [
     {
       category: "식비",
@@ -89,40 +56,20 @@ const MainPage: React.FC = () => {
     },
   ];
 
-  const [showBubble, setShowBubble] = useState<boolean>(false);
-  const [selectedData, setSelectedBubble] = useState<DataProps>();
-  const [categoryInfo, setCategoryInfo] = useState<CategoryProps>();
   const showBubbleInfo = (idx: number) => {
     setShowBubble(true);
     setSelectedBubble(dummyDatas[idx]);
   };
 
+  useGetMyCurrentLocation(setLocation, setCenter);
+
   useEffect(() => {
     if (!selectedData?.category) return;
     setCategoryInfo(findCategory(selectedData!.category));
   }, [selectedData]);
-
-  const showBubbleRef = useRef<HTMLDivElement>(null!);
-  useClickOutside(showBubbleRef, () => setShowBubble(false));
-
   return (
     <>
-      <Map
-        key={`map-${mapCenter.lat}-${mapCenter.lng}`}
-        center={{ lat: mapCenter.lat, lng: mapCenter.lng }}
-        style={{
-          width: "100%",
-          height: "100%",
-          position: "absolute",
-        }}
-        isPanto={true}
-        level={level}
-        ref={mapRef}
-        onZoomChanged={(map) => {
-          const level = map.getLevel();
-          setLevel(level);
-        }}
-      >
+      <KakaoMap>
         <MyCurrentLocation
           location={{ lat: location.lat, lng: location.lng }}
         />
@@ -130,7 +77,7 @@ const MainPage: React.FC = () => {
           <MapBubble
             onClick={() => showBubbleInfo(index)}
             key={index}
-            type={level >= 5 ? "icon" : "bubble"}
+            type={mapInfo.level >= 5 ? "icon" : "bubble"}
             position={{
               lat: location.lat + (index + 1) * 0.001,
               lng: location.lng + (index + 1) * 0.001,
@@ -140,35 +87,16 @@ const MainPage: React.FC = () => {
             count={data.count}
           />
         ))}
-      </Map>
+      </KakaoMap>
       <div className="flex flex-col justify-between w-full h-full px-6 pt-10 pb-5">
         <MapHeader />
-        <div className="z-10 flex flex-col gap-3">
-          <div className="flex items-end justify-between">
-            <IconMoveMyLocation moveToCurrentLocation={moveToCurrentLocation} />
-            <IconFastInputPay />
-          </div>
-          {showBubble && (
-            <div
-              ref={showBubbleRef}
-              className="flex flex-col gap-2 p-3 bg-white rounded-lg drop-shadow-10"
-            >
-              <div className="flex items-center justify-between">
-                {selectedData!.place}
-                <div
-                  className={`flex items-center gap-1 rounded-lg border px-1.5 py-1 ${categoryInfo?.bgColor} ${categoryInfo?.borderColor}`}
-                >
-                  <div>{categoryInfo?.icon({ size: 16 })}</div>
-                  <div className="text-sm">{selectedData!.category}</div>
-                </div>
-              </div>
-              <div className="text-xs font-light">{selectedData!.detail}</div>
-              <div className="text-right">
-                {formatPrice(selectedData!.price)}원
-              </div>
-            </div>
-          )}
-        </div>
+        <MapBottom
+          location={location}
+          selectedData={selectedData}
+          categoryInfo={categoryInfo}
+          showBubble={showBubble}
+          setShowBubble={setShowBubble}
+        />
       </div>
     </>
   );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -33,7 +33,7 @@ interface DataProps {
 
 const MainPage: React.FC = () => {
   const [location, setLocation] = useState({ lat: 0, lng: 0 });
-  const { mapInfo, setCenter } = useMapInfo();
+  const { level, setMapCenter, setMyLocation, myLocation } = useMapInfo();
   const [showBubble, setShowBubble] = useState<boolean>(false);
   const [selectedData, setSelectedBubble] = useState<DataProps>();
   const [categoryInfo, setCategoryInfo] = useState<CategoryProps>();
@@ -61,7 +61,7 @@ const MainPage: React.FC = () => {
     setSelectedBubble(dummyDatas[idx]);
   };
 
-  useGetMyCurrentLocation(setLocation, setCenter);
+  useGetMyCurrentLocation(setMyLocation, setMapCenter);
 
   useEffect(() => {
     if (!selectedData?.category) return;
@@ -71,16 +71,16 @@ const MainPage: React.FC = () => {
     <>
       <KakaoMap>
         <MyCurrentLocation
-          location={{ lat: location.lat, lng: location.lng }}
+          location={{ lat: myLocation.lat, lng: myLocation.lng }}
         />
         {dummyDatas.map((data, index) => (
           <MapBubble
             onClick={() => showBubbleInfo(index)}
             key={index}
-            type={mapInfo.level >= 5 ? "icon" : "bubble"}
+            type={level >= 5 ? "icon" : "bubble"}
             position={{
-              lat: location.lat + (index + 1) * 0.001,
-              lng: location.lng + (index + 1) * 0.001,
+              lat: myLocation.lat + (index + 1) * 0.001,
+              lng: myLocation.lng + (index + 1) * 0.001,
             }}
             category={data.category}
             price={data.price}
@@ -91,7 +91,6 @@ const MainPage: React.FC = () => {
       <div className="flex flex-col justify-between w-full h-full px-6 pt-10 pb-5">
         <MapHeader />
         <MapBottom
-          location={location}
           selectedData={selectedData}
           categoryInfo={categoryInfo}
           showBubble={showBubble}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { CustomOverlayMap, Map } from "react-kakao-maps-sdk";
 import MapHeader from "../components/MapHeader";
 import IconMyLocation from "../assets/IconMyLocation";
@@ -6,7 +6,10 @@ import { LucidePlus } from "lucide-react";
 import MapBubble from "../components/MapBubble";
 import { useMovePage } from "../hooks/useMovePage";
 import useGetMyCurrentLocation from "../hooks/useGetMyCurrentLocation";
-import MapIconMarker from "../components/MapIconMarker";
+import { formatPrice } from "../utils/formatPrice";
+import { findCategory } from "../utils/findTypeOrCategory";
+import { CategoryProps } from "../constants/category";
+import useClickOutside from "../hooks/useClickOutside";
 
 const IconMoveMyLocation: React.FC<{ moveToCurrentLocation: () => void }> = ({
   moveToCurrentLocation,
@@ -14,7 +17,7 @@ const IconMoveMyLocation: React.FC<{ moveToCurrentLocation: () => void }> = ({
   return (
     <div
       onClick={moveToCurrentLocation}
-      className="z-10 grid aspect-square w-10 place-items-center rounded-full bg-white drop-shadow-50"
+      className="z-10 grid w-10 bg-white rounded-full aspect-square place-items-center drop-shadow-50"
     >
       <IconMyLocation />
     </div>
@@ -25,7 +28,7 @@ const IconFastInputPay: React.FC = () => {
   return (
     <div
       onClick={() => moveToPage("/addpay")}
-      className="z-10 grid aspect-square w-11 place-items-center rounded-full bg-main drop-shadow-50"
+      className="z-10 grid rounded-full aspect-square w-11 place-items-center bg-main drop-shadow-50"
     >
       <LucidePlus size={24} color="#FFF" />
     </div>
@@ -40,8 +43,8 @@ const MyCurrentLocation: React.FC<{
       position={{ lat: location.lat, lng: location.lng }}
       zIndex={1}
     >
-      <div className="grid aspect-square w-8 animate-pulse place-items-center rounded-full bg-main bg-opacity-30"></div>
-      <div className="absolute left-1/2 top-1/2 aspect-square w-4 -translate-x-1/2 -translate-y-1/2 transform rounded-full border-2 border-white bg-main"></div>
+      <div className="grid w-8 rounded-full aspect-square animate-pulse place-items-center bg-main bg-opacity-30"></div>
+      <div className="absolute w-4 transform -translate-x-1/2 -translate-y-1/2 border-2 border-white rounded-full left-1/2 top-1/2 aspect-square bg-main"></div>
     </CustomOverlayMap>
   );
 };
@@ -61,18 +64,46 @@ const MainPage: React.FC = () => {
     setMapCenter({ lat: location.lat, lng: location.lng });
   };
 
+  interface DataProps {
+    category: string;
+    price: number;
+    count: number;
+    detail: string;
+    place: string;
+  }
+
   const dummyDatas = [
     {
       category: "식비",
       price: 2000,
       count: 3,
+      detail: "한국경제신문에서 밥머금",
+      place: "맥도날드",
     },
     {
-      category: "주거",
+      category: "교통",
       price: 50000,
       count: 2,
+      detail: "한국경제신문에서 버스탐",
+      place: "버스",
     },
   ];
+
+  const [showBubble, setShowBubble] = useState<boolean>(false);
+  const [selectedData, setSelectedBubble] = useState<DataProps>();
+  const [categoryInfo, setCategoryInfo] = useState<CategoryProps>();
+  const showBubbleInfo = (idx: number) => {
+    setShowBubble(true);
+    setSelectedBubble(dummyDatas[idx]);
+  };
+
+  useEffect(() => {
+    if (!selectedData?.category) return;
+    setCategoryInfo(findCategory(selectedData!.category));
+  }, [selectedData]);
+
+  const showBubbleRef = useRef<HTMLDivElement>(null!);
+  useClickOutside(showBubbleRef, () => setShowBubble(false));
 
   return (
     <>
@@ -95,35 +126,48 @@ const MainPage: React.FC = () => {
         <MyCurrentLocation
           location={{ lat: location.lat, lng: location.lng }}
         />
-        {dummyDatas.map((data, index) =>
-          level >= 5 ? (
-            <MapIconMarker
-              key={index}
-              position={{
-                lat: location.lat + (index + 1) * 0.001,
-                lng: location.lng + (index + 1) * 0.001,
-              }}
-              category={data.category}
-            />
-          ) : (
-            <MapBubble
-              key={index}
-              position={{
-                lat: location.lat + (index + 1) * 0.001,
-                lng: location.lng + (index + 1) * 0.001,
-              }}
-              category={data.category}
-              price={data.price}
-              count={data.count}
-            />
-          ),
-        )}
+        {dummyDatas.map((data, index) => (
+          <MapBubble
+            onClick={() => showBubbleInfo(index)}
+            key={index}
+            type={level >= 5 ? "icon" : "bubble"}
+            position={{
+              lat: location.lat + (index + 1) * 0.001,
+              lng: location.lng + (index + 1) * 0.001,
+            }}
+            category={data.category}
+            price={data.price}
+            count={data.count}
+          />
+        ))}
       </Map>
-      <div className="flex h-full w-full flex-col justify-between px-6 pb-5 pt-10">
+      <div className="flex flex-col justify-between w-full h-full px-6 pt-10 pb-5">
         <MapHeader />
-        <div className="flex items-end justify-between">
-          <IconMoveMyLocation moveToCurrentLocation={moveToCurrentLocation} />
-          <IconFastInputPay />
+        <div className="z-10 flex flex-col gap-3">
+          <div className="flex items-end justify-between">
+            <IconMoveMyLocation moveToCurrentLocation={moveToCurrentLocation} />
+            <IconFastInputPay />
+          </div>
+          {showBubble && (
+            <div
+              ref={showBubbleRef}
+              className="flex flex-col gap-2 p-3 bg-white rounded-lg drop-shadow-10"
+            >
+              <div className="flex items-center justify-between">
+                {selectedData!.place}
+                <div
+                  className={`flex items-center gap-1 rounded-lg border px-1.5 py-1 ${categoryInfo?.bgColor} ${categoryInfo?.borderColor}`}
+                >
+                  <div>{categoryInfo?.icon({ size: 16 })}</div>
+                  <div className="text-sm">{selectedData!.category}</div>
+                </div>
+              </div>
+              <div className="text-xs font-light">{selectedData!.detail}</div>
+              <div className="text-right">
+                {formatPrice(selectedData!.price)}원
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/src/stores/mapInfo.tsx
+++ b/src/stores/mapInfo.tsx
@@ -1,36 +1,25 @@
 import { create } from "zustand";
 
-interface MapInfo {
-  center: { lat: number; lng: number };
-  level: number;
-  ref: React.RefObject<kakao.maps.Map | null>;
-}
-
 interface MapStore {
-  mapInfo: MapInfo;
-  setCenter: (center: { lat: number; lng: number }) => void;
+  myLocation: { lat: number; lng: number };
+  setMyLocation: (location: { lat: number; lng: number }) => void;
+  mapCenter: { lat: number; lng: number };
+  setMapCenter: (center: { lat: number; lng: number }) => void;
+  level: number;
   setLevel: (level: number) => void;
-  setRef: (ref: React.RefObject<kakao.maps.Map | null>) => void;
+  mapRef: React.RefObject<kakao.maps.Map | null>;
+  setMapRef: (ref: React.RefObject<kakao.maps.Map | null>) => void;
 }
 
 const useMapInfo = create<MapStore>((set) => ({
-  mapInfo: {
-    center: { lat: 0, lng: 0 },
-    level: 3,
-    ref: { current: null },
-  },
-  setCenter: (center: { lat: number; lng: number }) =>
-    set((state) => ({
-      mapInfo: { ...state.mapInfo, center },
-    })),
-  setLevel: (level: number) =>
-    set((state) => ({
-      mapInfo: { ...state.mapInfo, level },
-    })),
-  setRef: (ref: React.RefObject<kakao.maps.Map | null>) =>
-    set((state) => ({
-      mapInfo: { ...state.mapInfo, ref },
-    })),
+  myLocation: { lat: 0, lng: 0 },
+  setMyLocation: (location) => set({ myLocation: location }),
+  mapCenter: { lat: 0, lng: 0 },
+  setMapCenter: (center) => set({ mapCenter: center }),
+  level: 3,
+  setLevel: (level) => set({ level }),
+  mapRef: { current: null },
+  setMapRef: (mapRef) => set({ mapRef }),
 }));
 
 export default useMapInfo;

--- a/src/stores/mapInfo.tsx
+++ b/src/stores/mapInfo.tsx
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+
+interface MapInfo {
+  center: { lat: number; lng: number };
+  level: number;
+  ref: React.RefObject<kakao.maps.Map | null>;
+}
+
+interface MapStore {
+  mapInfo: MapInfo;
+  setCenter: (center: { lat: number; lng: number }) => void;
+  setLevel: (level: number) => void;
+  setRef: (ref: React.RefObject<kakao.maps.Map | null>) => void;
+}
+
+const useMapInfo = create<MapStore>((set) => ({
+  mapInfo: {
+    center: { lat: 0, lng: 0 },
+    level: 3,
+    ref: { current: null },
+  },
+  setCenter: (center: { lat: number; lng: number }) =>
+    set((state) => ({
+      mapInfo: { ...state.mapInfo, center },
+    })),
+  setLevel: (level: number) =>
+    set((state) => ({
+      mapInfo: { ...state.mapInfo, level },
+    })),
+  setRef: (ref: React.RefObject<kakao.maps.Map | null>) =>
+    set((state) => ({
+      mapInfo: { ...state.mapInfo, ref },
+    })),
+}));
+
+export default useMapInfo;


### PR DESCRIPTION
## #️⃣ 요약 설명
지도 정보 띄우기 및 아이콘 리스트 변경

## 📝 작업 내용

- 아이콘 사용방법 변경
- 지도 정보 스토어로 관리
- 메인페이지 리팩토링

<img width="530" alt="image" src="https://github.com/user-attachments/assets/249bd3bb-55a1-4967-80f5-56c26a2568ef" />
myLocation = 내 위치 좌표
mapCenter = 지도의 중앙좌표
level = 지도의 줌 레벨

## 👀 이미지 첨부(선택)


## 💬 리뷰 요구사항(선택)
