### PR TITLE
[CHORE-37] API 연동을 위한 설정

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: import.meta.env.VITE_BASE_URL,
+});
+
+api.interceptors.request.use(
+  (config) => {
+    const token =
+      "eyJhbGciOiJIUzI1NiJ9.eyJtZW1iZXJJZCI6IjIiLCJlbWFpbCI6ImFiY0BtYWlsLmNvbSIsImlhdCI6MTc0MTEzODcxOCwiZXhwIjoxNzQxNzQzNTE4fQ.1P1EnkNtOoJcJeWplqE4D-rcB_KHSL3esRqXAHRwt6o";
+
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "strict": true,
     "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
-    "types": ["kakao.maps.d.ts"]
+    "types": ["kakao.maps.d.ts", "vite/client"]
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/vite.env.d.ts
+++ b/vite.env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly VITE_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
API 연동을 위한 설정

## 📝 작업 내용

- axios base url 설정
- access token 고정으로 넣어둠

```javascript
api.get("/budget")
```
이런식으로 사용하면 됩니당
앞에 axios 붙이는거 아님!! api 붙여야 됨!!

## 💻 동작 확인
<img width="984" alt="image" src="https://github.com/user-attachments/assets/4d099e32-d5fd-474e-b3f2-58d10dcf99de" />


## 👀 이미지 첨부(선택)


## 💬 리뷰 요구사항(선택)

.env 파일에 base url 넣어야 됩니다~
