### PR TITLE
[FEAT_40] 로그인/회원가입 API 연동

### DIFF
--- a/src/components/AddPayInput.tsx
+++ b/src/components/AddPayInput.tsx
@@ -16,7 +16,7 @@ const AddPayInput: React.FC<AddPayInputProps> = ({ toggle, selectName }) => {
       <form className="flex flex-col gap-2 pt-3">
         <InputDefault
           label="금액"
-          type="number"
+          type="price"
           placeholder="금액을 입력하세요"
         />
         <InputDefault

--- a/src/components/SelectAgeGroup.tsx
+++ b/src/components/SelectAgeGroup.tsx
@@ -2,10 +2,13 @@ import React from "react";
 
 const SelectAgeGroup: React.FC<{
   selectedAge: string;
-  setSelectedAge: React.Dispatch<React.SetStateAction<string>>;
+  setSelectedAge:
+    | React.Dispatch<React.SetStateAction<string>>
+    | ((value: string) => void);
   style?: string;
 }> = ({ selectedAge, setSelectedAge, style = "" }) => {
   const ageGroups = ["10대", "20대", "30대", "40대", "50대~"];
+
   return (
     <div className={`flex flex-col gap-2 ${style}`}>
       <div className="text-sm">연령대</div>

--- a/src/components/common/InputDefault.tsx
+++ b/src/components/common/InputDefault.tsx
@@ -8,6 +8,7 @@ interface PayInputProps {
   isReadOnly?: boolean; // 읽기 전용 체크
   onClick?: () => void; // 이동할 페이지 핸들러
   value?: string; // 입력 값
+  onChange?: (value: string) => void;
 }
 
 const InputDefault: React.FC<PayInputProps> = ({
@@ -18,6 +19,7 @@ const InputDefault: React.FC<PayInputProps> = ({
   isReadOnly = false,
   value = "",
   onClick,
+  onChange,
 }) => {
   const [inputType, setInputType] = useState("type"); // 초기 타입 설정(문자열!)
   const [inputValue, setInputValue] = useState(value); // 입력값 상태 관리
@@ -27,7 +29,7 @@ const InputDefault: React.FC<PayInputProps> = ({
   }, [value]);
 
   const formatValue = (val: string) => {
-    if (type === "number" && val) {
+    if (type === "price" && val) {
       const num = Number(val.replace(/,/g, "")); // 쉼표 제거 후 숫자로 변환
       return num.toLocaleString(); // 쉼표 추가된 문자열 반환
     }
@@ -40,27 +42,32 @@ const InputDefault: React.FC<PayInputProps> = ({
     let newValue = e.target.value;
 
     // 숫자에 쉼표달기
-    if (type === "number") {
+    if (type === "price") {
       newValue = newValue.replace(/[^0-9]/g, ""); // 숫자만 허용
       newValue = formatValue(newValue); // 숫자일 경우 쉼표 추가
     }
 
+    if (type === "number") {
+      newValue = newValue.replace(/[^0-9]/g, ""); // 숫자만 허용
+    }
+
     setInputValue(newValue); // 상태 업데이트
+    onChange?.(newValue);
   };
 
   return (
     <div onClick={onClick} className={`h-15 ${style}`}>
-      <div className="mb-5 flex flex-col border-b py-3 focus-within:border-pink-500">
+      <div className="flex flex-col py-3 mb-5 border-b focus-within:border-pink-500">
         <div className="flex gap-5">
           {label && <label className="w-20">{label}</label>}
           <input
-            type={inputType}
+            type={type}
             placeholder={placeholder}
             readOnly={isReadOnly}
             value={inputValue}
             onChange={handleChange}
             onClick={(e) => isReadOnly && e.preventDefault()}
-            className="text-default outline-none focus:outline-none focus:ring-0"
+            className="w-full outline-none text-default focus:outline-none focus:ring-0"
             onFocus={() => type === "date" && setInputType("date")} // 누르면 달력 처럼
             onBlur={
               (e) => type === "date" && !e.target.value && setInputType("text") // 텍스트인 것처럼 보이게

--- a/src/components/sections/PayTypeSection.tsx
+++ b/src/components/sections/PayTypeSection.tsx
@@ -3,7 +3,9 @@ import { payTypeList } from "../../constants/payType";
 
 const PayTypeSection: React.FC<{
   selectedPayType: string;
-  setSelectedPayType: React.Dispatch<React.SetStateAction<string>>;
+  setSelectedPayType:
+    | React.Dispatch<React.SetStateAction<string>>
+    | ((value: string) => void);
 }> = ({ selectedPayType, setSelectedPayType }) => {
   return (
     <div className="grid grid-cols-2 gap-2">

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -4,7 +4,7 @@ import InputDefault from "../components/common/InputDefault";
 import { SaveButton } from "../components/common/Buttons";
 import { useMovePage } from "../hooks/useMovePage";
 import PageUrls from "../constants/PageUrls";
-import { api, apiWithoutAuth } from "../utils/api";
+import { apiWithoutAuth } from "../utils/api";
 
 const Logo = () => {
   return (
@@ -47,7 +47,10 @@ const LoginAndSignUp: React.FC<{
     email: string;
     password: string;
   };
-}> = ({ loginInfo }) => {
+  setLoginInfo: React.Dispatch<
+    React.SetStateAction<{ email: string; password: string }>
+  >;
+}> = ({ loginInfo, setLoginInfo }) => {
   const { moveToPage } = useMovePage();
   const handleClickLoginBtn = async () => {
     if (loginInfo.email === "" || loginInfo.password === "") return;
@@ -57,10 +60,14 @@ const LoginAndSignUp: React.FC<{
         email: loginInfo.email,
         password: loginInfo.password,
       });
+
       console.log(res.data);
+      localStorage.setItem("accessToken", res.data.accessToken);
       moveToPage(PageUrls.HOME);
     } catch (error) {
       console.error(error);
+      alert("정보를 다시 입력해주세요.");
+      setLoginInfo({ email: "", password: "" });
     }
   };
   return (
@@ -88,7 +95,7 @@ const LoginPage = () => {
     <div className="flex flex-col gap-10 px-6 py-10">
       <Logo />
       <Inputs loginInfo={loginInfo} setLoginInfo={setLoginInfo} />
-      <LoginAndSignUp loginInfo={loginInfo} />
+      <LoginAndSignUp loginInfo={loginInfo} setLoginInfo={setLoginInfo} />
     </div>
   );
 };

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import IconNoPayType from "../assets/payTypeIcons/IconNoPayType";
 import InputDefault from "../components/common/InputDefault";
 import { SaveButton } from "../components/common/Buttons";
 import { useMovePage } from "../hooks/useMovePage";
+import PageUrls from "../constants/PageUrls";
+import { api, apiWithoutAuth } from "../utils/api";
 
 const Logo = () => {
   return (
@@ -13,25 +15,62 @@ const Logo = () => {
   );
 };
 
-const Inputs = () => {
+const Inputs: React.FC<{
+  loginInfo: {
+    email: string;
+    password: string;
+  };
+  setLoginInfo: React.Dispatch<
+    React.SetStateAction<{ email: string; password: string }>
+  >;
+}> = ({ loginInfo, setLoginInfo }) => {
   return (
     <div className="flex flex-col">
-      <InputDefault placeholder="이메일" />
-      <InputDefault placeholder="비밀번호" />
+      <InputDefault
+        placeholder="이메일"
+        type="email"
+        value={loginInfo.email}
+        onChange={(value) => setLoginInfo({ ...loginInfo, email: value })}
+      />
+      <InputDefault
+        placeholder="비밀번호"
+        type="password"
+        value={loginInfo.password}
+        onChange={(value) => setLoginInfo({ ...loginInfo, password: value })}
+      />
     </div>
   );
 };
 
-const LoginAndSignUp = () => {
+const LoginAndSignUp: React.FC<{
+  loginInfo: {
+    email: string;
+    password: string;
+  };
+}> = ({ loginInfo }) => {
   const { moveToPage } = useMovePage();
+  const handleClickLoginBtn = async () => {
+    if (loginInfo.email === "" || loginInfo.password === "") return;
+    console.log(loginInfo);
+    try {
+      const res = await apiWithoutAuth.post("/login", {
+        email: loginInfo.email,
+        password: loginInfo.password,
+      });
+      console.log(res.data);
+      moveToPage(PageUrls.HOME);
+    } catch (error) {
+      console.error(error);
+    }
+  };
   return (
     <div>
-      <SaveButton title="로그인" style="mt-0 " />
+      <SaveButton title="로그인" style="mt-0 " onClick={handleClickLoginBtn} />
       <div className="flex items-center justify-center gap-2">
-        회원이 아니신가요?{" "}
+        회원이 아니신가요?
         <span
-          onClick={() => moveToPage("/signup")}
-          className="text-second underline underline-offset-2"
+          onClick={() => moveToPage(PageUrls.SIGNUP)}
+          className="underline text-second underline-offset-2"
         >
           회원가입
         </span>
@@ -41,11 +80,15 @@ const LoginAndSignUp = () => {
 };
 
 const LoginPage = () => {
+  const [loginInfo, setLoginInfo] = useState({
+    email: "",
+    password: "",
+  });
   return (
     <div className="flex flex-col gap-10 px-6 py-10">
       <Logo />
-      <Inputs />
-      <LoginAndSignUp />
+      <Inputs loginInfo={loginInfo} setLoginInfo={setLoginInfo} />
+      <LoginAndSignUp loginInfo={loginInfo} />
     </div>
   );
 };

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -7,11 +7,11 @@ import { SaveButton } from "../components/common/Buttons";
 import { LucideLogOut } from "lucide-react";
 import PayTypeSection from "../components/sections/PayTypeSection";
 import { useMovePage } from "../hooks/useMovePage";
+import PageUrls from "../constants/PageUrls";
 
 const ProfileTab = () => {
   const [selectedAge, setSelectedAge] = useState<string>("");
-  const { moveToPage } = useMovePage(); // 페이지 이동 핸들러
-
+  const { moveToPage } = useMovePage();
   return (
     <>
       <div className="flex flex-col py-5">
@@ -30,7 +30,7 @@ const ProfileTab = () => {
           placeholder="집 정보"
           label="집 정보"
           type="location"
-          onClick={() => moveToPage("/search/location")}
+          onClick={() => moveToPage(PageUrls.SEARCH_LOCATION)}
         />
       </div>
       <SaveButton title="프로필 저장" />
@@ -46,7 +46,7 @@ const TypeTab = () => {
   const [selectedPayType, setSelectedPayType] = useState<string>("");
   return (
     <>
-      <div className="flex flex-col gap-5 rounded-lg border border-second-light px-3 py-7">
+      <div className="flex flex-col gap-5 px-3 border rounded-lg border-second-light py-7">
         <div className="flex flex-col">
           <div className="text-lg font-bold">소비성향 설정</div>
           <div className="text-sm">
@@ -70,7 +70,7 @@ const MyPage = () => {
   const tabs = ["프로필", "성향"];
 
   return (
-    <div className="flex w-full flex-col gap-2">
+    <div className="flex flex-col w-full gap-2">
       <div className="flex items-center gap-2 py-4">
         <div>{userType?.icon({ size: 48 })}</div>
         <div>

--- a/src/pages/SearchLocation.tsx
+++ b/src/pages/SearchLocation.tsx
@@ -1,14 +1,43 @@
-import { LucideX } from "lucide-react";
 import DaumPostcodeEmbed from "react-daum-postcode";
 import Header from "../components/common/Header";
+import { useMovePage } from "../hooks/useMovePage";
+import PageUrls from "../constants/PageUrls";
+import useSignupInfo from "../stores/signupInfo";
 
 const SearchLocation = () => {
-  const onComplete = (data: any) => {
-    console.log(data.jibunAddress);
+  const { moveToPage } = useMovePage();
+  const { setSignupInfo } = useSignupInfo();
+
+  const getCoordinates = async (address: string) => {
+    const API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+    const url = `https://dapi.kakao.com/v2/local/search/address.json?query=${encodeURIComponent(address)}`;
+
+    try {
+      const response = await fetch(url, {
+        headers: { Authorization: `KakaoAK ${API_KEY}` },
+      });
+      const data = await response.json();
+
+      if (data.documents.length > 0) {
+        const { x, y } = data.documents[0];
+        setSignupInfo("location", address);
+        setSignupInfo("home", { lat: parseFloat(y), lng: parseFloat(x) });
+      } else {
+        console.error("주소를 찾을 수 없습니다.");
+      }
+    } catch (error) {
+      console.error("좌표 변환 오류:", error);
+    }
   };
+
+  const onComplete = async (data: any) => {
+    await getCoordinates(data.address);
+    moveToPage(PageUrls.SIGNUP);
+  };
+
   return (
-    <div className="flex h-full w-full flex-col">
-      <Header title="주소검색" />
+    <div className="flex flex-col w-full h-full">
+      <Header />
       <DaumPostcodeEmbed style={{ height: "100%" }} onComplete={onComplete} />
     </div>
   );

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,31 +1,137 @@
-import React, { useState } from "react";
+import React from "react";
 import InputDefault from "../components/common/InputDefault";
-import { payTypeList } from "../constants/payType";
 import PayTypeSection from "../components/sections/PayTypeSection";
 import { SaveButton } from "../components/common/Buttons";
 import SelectAgeGroup from "../components/SelectAgeGroup";
+import { apiWithoutAuth } from "../utils/api";
+import PageUrls from "../constants/PageUrls";
+import { useMovePage } from "../hooks/useMovePage";
+import useSignupInfo from "../stores/signupInfo";
 
-const SignupInputs = () => {
+export interface signupInfo {
+  email: string;
+  code: string;
+  password: string;
+  checkPassword: string;
+  nickName: string;
+  location: string;
+  home: {
+    lat: number;
+    lng: number;
+  };
+  ageGroup: string;
+  type: string;
+}
+
+const SignupInputs: React.FC<{
+  signupInfo: signupInfo;
+  handleInputChange: (key: keyof signupInfo, value: string) => void;
+  setIsMailCertified: (value: boolean) => void;
+}> = ({ signupInfo, handleInputChange, setIsMailCertified }) => {
+  const { moveToPage } = useMovePage();
+  const handleClickCetifyMail = async () => {
+    if (!signupInfo.email) {
+      alert("이메일을 입력해주세요.");
+      return;
+    }
+    try {
+      const res = await apiWithoutAuth.post("/mail/send", {
+        email: signupInfo.email,
+      });
+      console.log(res.data);
+      alert("인증 메일이 발송되었습니다.");
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleClickCheckMail = async () => {
+    if (!signupInfo.email) {
+      alert("인증번호를 입력해주세요.");
+      return;
+    }
+    try {
+      const res = await apiWithoutAuth.post("/mail/verify", {
+        email: signupInfo.email,
+        code: signupInfo.code,
+      });
+      console.log(res.data);
+
+      if (res.data.result.check) {
+        setIsMailCertified(true);
+        alert("인증되었습니다.");
+      } else {
+        alert("인증에 실패했습니다.");
+      }
+    } catch (error) {
+      console.error(error);
+      alert("인증에 실패했습니다.");
+    }
+  };
+
   return (
     <>
-      <InputDefault placeholder="이메일" />
-      <div className="flex w-full items-end gap-3">
-        <InputDefault placeholder="이메일 인증번호" style="w-full" />
-        <div className="mb-5 grid h-10 w-16 shrink-0 place-items-center gap-3 rounded-lg bg-second-light font-medium text-white">
+      <div className="flex items-end w-full gap-3">
+        <InputDefault
+          style="w-full"
+          placeholder="이메일"
+          type="email"
+          value={signupInfo.email}
+          onChange={(value) => handleInputChange("email", value)}
+        />
+        <div
+          onClick={handleClickCetifyMail}
+          className="grid w-16 h-10 gap-3 mb-5 font-medium text-white rounded-lg shrink-0 place-items-center bg-second-light"
+        >
+          전송
+        </div>
+      </div>
+      <div className="flex items-end w-full gap-3">
+        <InputDefault
+          placeholder="이메일 인증번호"
+          style="w-full"
+          type="number"
+          value={signupInfo.code}
+          onChange={(value) => handleInputChange("code", value)}
+        />
+        <div
+          onClick={handleClickCheckMail}
+          className="grid w-16 h-10 gap-3 mb-5 font-medium text-white rounded-lg shrink-0 place-items-center bg-second-light"
+        >
           확인
         </div>
       </div>
-      <InputDefault placeholder="비밀번호" />
-      <InputDefault placeholder="비밀번호 확인" />
-      <InputDefault placeholder="닉네임" />
-      <InputDefault placeholder="집 정보 입력" type="location" />
+      <InputDefault
+        placeholder="비밀번호"
+        type="password"
+        value={signupInfo.password}
+        onChange={(value) => handleInputChange("password", value)}
+      />
+      <InputDefault
+        placeholder="비밀번호 확인"
+        type="password"
+        value={signupInfo.checkPassword}
+        onChange={(value) => handleInputChange("checkPassword", value)}
+      />
+      <InputDefault
+        placeholder="닉네임"
+        value={signupInfo.nickName}
+        onChange={(value) => handleInputChange("nickName", value)}
+      />
+      <InputDefault
+        placeholder="집 정보 입력"
+        type="location"
+        onClick={() => moveToPage(PageUrls.SEARCH_LOCATION)}
+        value={signupInfo.location}
+        isReadOnly
+      />
     </>
   );
 };
 
 const SelectPayType: React.FC<{
   selectedPayType: string;
-  setSelectedPayType: React.Dispatch<React.SetStateAction<string>>;
+  setSelectedPayType: (value: string) => void;
 }> = ({ selectedPayType, setSelectedPayType }) => {
   return (
     <div className="flex flex-col gap-2">
@@ -42,23 +148,63 @@ const SelectPayType: React.FC<{
 };
 
 const SignupPage = () => {
-  const [selectedAge, setSelectedAge] = useState<string>("");
-  const [selectedPayType, setSelectedPayType] = useState<string>("");
+  const { signupInfo, setSignupInfo, resetSignupInfo } = useSignupInfo();
+  const { moveToPage } = useMovePage();
+
+  const [isMailCertified, setIsMailCertified] = React.useState(false);
+
+  const isSignupInfoComplete = Object.values(signupInfo).every((value) => {
+    if (typeof value === "object" && value !== null) {
+      return Object.values(value).every((nestedValue) => nestedValue !== 0);
+    }
+    return value !== "";
+  });
+
+  const handleClickSignup = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    console.log(signupInfo);
+    if (isMailCertified === false) return alert("메일 인증을 해주세요.");
+    if (!isSignupInfoComplete) return alert("모든 정보를 입력해주세요.");
+
+    try {
+      const res = await apiWithoutAuth.post("/members/join", {
+        email: signupInfo.email,
+        password: signupInfo.password,
+        nickName: signupInfo.nickName,
+        type: signupInfo.type,
+        home: signupInfo.home,
+        ageGroup: signupInfo.ageGroup,
+      });
+      console.log(res.data);
+      moveToPage(PageUrls.HOME);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      resetSignupInfo();
+    }
+  };
 
   return (
     <>
-      <div className="flex flex-col gap-5 px-6 py-5">
-        <SignupInputs />
+      <form
+        onSubmit={handleClickSignup}
+        className="flex flex-col gap-5 px-6 py-5"
+      >
+        <SignupInputs
+          signupInfo={signupInfo}
+          handleInputChange={setSignupInfo}
+          setIsMailCertified={setIsMailCertified}
+        />
         <SelectAgeGroup
-          selectedAge={selectedAge}
-          setSelectedAge={setSelectedAge}
+          selectedAge={signupInfo.ageGroup}
+          setSelectedAge={(value: string) => setSignupInfo("ageGroup", value)}
         />
         <SelectPayType
-          selectedPayType={selectedPayType}
-          setSelectedPayType={setSelectedPayType}
+          selectedPayType={signupInfo.type}
+          setSelectedPayType={(value: string) => setSignupInfo("type", value)}
         />
         <SaveButton title="회원가입" />
-      </div>
+      </form>
     </>
   );
 };

--- a/src/stores/signupInfo.tsx
+++ b/src/stores/signupInfo.tsx
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+import { signupInfo } from "../pages/SignupPage";
+
+interface SignupInfoStore {
+  signupInfo: signupInfo;
+  setSignupInfo: (key: keyof signupInfo, value: string | object) => void;
+  resetSignupInfo: () => void;
+}
+
+const useSignupInfo = create<SignupInfoStore>((set) => ({
+  signupInfo: {
+    email: "",
+    code: "",
+    password: "",
+    checkPassword: "",
+    nickName: "",
+    location: "",
+    home: {
+      lat: 0,
+      lng: 0,
+    },
+    ageGroup: "",
+    type: "",
+  },
+
+  setSignupInfo: (key, value) => {
+    set((prev) => ({
+      signupInfo: {
+        ...prev.signupInfo,
+        [key]: value,
+      },
+    }));
+  },
+  resetSignupInfo: () => {
+    set({
+      signupInfo: {
+        email: "",
+        code: "",
+        password: "",
+        checkPassword: "",
+        nickName: "",
+        location: "",
+        home: {
+          lat: 0,
+          lng: 0,
+        },
+        ageGroup: "",
+        type: "",
+      },
+    });
+  },
+}));
+
+export default useSignupInfo;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -4,6 +4,10 @@ export const api = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL,
 });
 
+export const apiWithoutAuth = axios.create({
+  baseURL: import.meta.env.VITE_BASE_URL,
+});
+
 api.interceptors.request.use(
   (config) => {
     const token =

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -10,8 +10,7 @@ export const apiWithoutAuth = axios.create({
 
 api.interceptors.request.use(
   (config) => {
-    const token =
-      "eyJhbGciOiJIUzI1NiJ9.eyJtZW1iZXJJZCI6IjIiLCJlbWFpbCI6ImFiY0BtYWlsLmNvbSIsImlhdCI6MTc0MTEzODcxOCwiZXhwIjoxNzQxNzQzNTE4fQ.1P1EnkNtOoJcJeWplqE4D-rcB_KHSL3esRqXAHRwt6o";
+    const token = localStorage.getItem("accessToken");
 
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;


### PR DESCRIPTION
## #️⃣ 요약 설명
로그인/회원가입 API 연동

## 📝 작업 내용

- 로그인 API 연동
- 회원가입 API 연동
- accessToken을 localStoarge에 저장

## 💻 동작 확인
- 정보를 모두 입력 후, 회원가입 버튼을 누르면 로그인 페이지로 이동
- 로그인 완료되면 홈으로 이동


## 👀 이미지 첨부(선택)
<img width="323" alt="image" src="https://github.com/user-attachments/assets/d48b28ec-df00-40ed-87fb-c96ba28af3d1" />
이메일 입력 input 옆에 전송 버튼 추가됨

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?