### PR TITLE
[FEAT-48] 통계 페이지 api 연동

### DIFF
--- a/src/components/charts/BarChart.tsx
+++ b/src/components/charts/BarChart.tsx
@@ -1,29 +1,44 @@
 import { Bar } from "react-chartjs-2";
 import "chart.js/auto";
 import { findCategory } from "../../utils/findTypeOrCategory";
+import { useEffect, useMemo } from "react";
+import { AnalyticsData } from "../../pages/StatisticPage";
 
-const BarChart = () => {
-  const labels = ["1월", "2월", "3월"];
+const BarChart: React.FC<{
+  monthPay?: AnalyticsData[];
+  prevPay?: AnalyticsData[];
+  twoMonthsAgoPay?: AnalyticsData[];
+}> = ({ monthPay = [], prevPay = [], twoMonthsAgoPay = [] }) => {
+  const categories = useMemo(() => {
+    const allCategories = [
+      ...monthPay.map((d) => d.category),
+      ...prevPay.map((d) => d.category),
+      ...twoMonthsAgoPay.map((d) => d.category),
+    ];
+    return [...new Set(allCategories)];
+  }, [monthPay, prevPay, twoMonthsAgoPay]);
+
+  const getCategoryData = (category: string, data: AnalyticsData[]) => {
+    return data.find((d) => d.category === category)?.price || 0;
+  };
+
+  const labels = [
+    monthPay[0]?.date,
+    prevPay[0]?.date,
+    twoMonthsAgoPay[0]?.date,
+  ].filter(Boolean);
 
   const data = {
     labels,
-    datasets: [
-      {
-        label: "식비",
-        data: [65, 59, 100],
-        backgroundColor: findCategory("식비")?.border,
-      },
-      {
-        label: "교통",
-        data: [45, 69, 60],
-        backgroundColor: findCategory("교통")?.border,
-      },
-      {
-        label: "쇼핑",
-        data: [25, 39, 50],
-        backgroundColor: findCategory("쇼핑")?.border,
-      },
-    ],
+    datasets: categories.map((category) => ({
+      label: category,
+      data: [
+        getCategoryData(category, monthPay),
+        getCategoryData(category, prevPay),
+        getCategoryData(category, twoMonthsAgoPay),
+      ],
+      backgroundColor: findCategory(category)?.border || "#ccc",
+    })),
   };
 
   const options = {
@@ -33,6 +48,7 @@ const BarChart = () => {
         labels: {
           boxWidth: 20,
           padding: 20,
+          boxHeight: 10,
         },
       },
     },
@@ -45,6 +61,7 @@ const BarChart = () => {
       },
     },
   };
+
   return <Bar data={data} options={options} />;
 };
 

--- a/src/components/charts/DoughnutChart.tsx
+++ b/src/components/charts/DoughnutChart.tsx
@@ -1,32 +1,30 @@
 import React from "react";
 import { Doughnut } from "react-chartjs-2";
 import { findCategory } from "../../utils/findTypeOrCategory";
-import { CategoryPay } from "../../pages/StatisticPage";
+import { AnalyticsData } from "../../pages/StatisticPage";
 
-const DoughnutChart: React.FC<{ categoryPay: CategoryPay[] }> = ({
-  categoryPay,
-}) => {
-  const labels = categoryPay
-    .filter((item) => item.spendPrice > 0)
-    .slice(0, 3)
-    .map((item) => item.category);
+const DoughnutChart: React.FC<{ categoryPay?: any }> = ({ categoryPay }) => {
+  const categories = categoryPay?.analyicsInfoDTOS || [];
+  const labels = categories.map((category: AnalyticsData) => category.category);
 
-  const data = {
-    labels,
+  const datas = {
+    labels: labels,
     datasets: [
       {
-        data: [65, 59, 100],
-        backgroundColor: [
-          findCategory("식비")?.border,
-          findCategory("교통")?.border,
-          findCategory("쇼핑")?.border,
-        ],
+        label: "지출 내역",
+        data: categories.map((category: AnalyticsData) => category.price), // 가격 배열
+        backgroundColor: categories.map(
+          (category: AnalyticsData) =>
+            findCategory(category.category)?.border || "#ccc",
+        ),
+        borderWidth: labels.length < 2 ? 0 : 2,
       },
     ],
   };
 
   const options = {
     responsive: true,
+
     plugins: {
       legend: {
         labels: {
@@ -36,7 +34,8 @@ const DoughnutChart: React.FC<{ categoryPay: CategoryPay[] }> = ({
       },
     },
   };
-  return <Doughnut data={data} options={options}></Doughnut>;
+
+  return <Doughnut data={datas} options={options} />;
 };
 
 export default DoughnutChart;

--- a/src/components/charts/DoughnutChart.tsx
+++ b/src/components/charts/DoughnutChart.tsx
@@ -1,9 +1,16 @@
 import React from "react";
 import { Doughnut } from "react-chartjs-2";
 import { findCategory } from "../../utils/findTypeOrCategory";
+import { CategoryPay } from "../../pages/StatisticPage";
 
-const DoughnutChart = () => {
-  const labels = ["1월", "2월", "3월"];
+const DoughnutChart: React.FC<{ categoryPay: CategoryPay[] }> = ({
+  categoryPay,
+}) => {
+  const labels = categoryPay
+    .filter((item) => item.spendPrice > 0)
+    .slice(0, 3)
+    .map((item) => item.category);
+
   const data = {
     labels,
     datasets: [

--- a/src/pages/StatisticPage.tsx
+++ b/src/pages/StatisticPage.tsx
@@ -1,40 +1,53 @@
 import { LucideChevronRight } from "lucide-react";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { SaveButton } from "../components/common/Buttons";
 import { categoryList } from "../constants/category";
 import BarChart from "../components/charts/BarChart";
 import DoughnutChart from "../components/charts/DoughnutChart";
 import BarGraph from "../components/BarGraph";
+import { api } from "../utils/api";
+import { formatPrice } from "../utils/formatFunc";
+import { useMovePage } from "../hooks/useMovePage";
+import PageUrls from "../constants/PageUrls";
+import { findCategory } from "../utils/findTypeOrCategory";
 
 const BoxWrapper: React.FC<{ children: ReactNode }> = ({ children }) => {
   return (
-    <div className="flex flex-col gap-2 px-4 py-5 bg-white rounded-2xl drop-shadow-10">
+    <div className="flex flex-col gap-2 rounded-2xl bg-white px-4 py-5 drop-shadow-10">
       {children}
     </div>
   );
 };
 
-const MonthPayBox = () => {
+const MonthPayBox: React.FC<{ monthPay: number; restBudget: number }> = ({
+  monthPay,
+  restBudget,
+}) => {
+  const { moveToPage } = useMovePage();
   return (
     <BoxWrapper>
       <div>이번 달 지출</div>
-      <div className="flex items-center gap-2 text-xl font-medium">
-        210,000원
+      <div
+        onClick={() => moveToPage(PageUrls.PAY_RECODE)}
+        className="flex items-center gap-2 text-xl font-medium"
+      >
+        {formatPrice(monthPay)}원
         <LucideChevronRight size={24} color="#333" />
       </div>
       <div className="py-2.5">
-        <BarGraph props={40} height="h-5" /> 
+        <BarGraph props={40} height="h-5" />
       </div>
 
       <div className="flex items-center justify-between">
         <div>남은예산</div>
-        <div className="text-xl font-medium">100,000원</div>
+        <div className="text-xl font-medium">{formatPrice(restBudget)}원</div>
       </div>
     </BoxWrapper>
   );
 };
 
 const PrevMonthPayBox = () => {
+  const { moveToPage } = useMovePage();
   return (
     <BoxWrapper>
       <div>지난 달보다</div>
@@ -45,46 +58,101 @@ const PrevMonthPayBox = () => {
       <div className="py-5">
         <BarChart />
       </div>
-      <SaveButton title="예산 설정하러 가기" style="mb-0" />
+      <SaveButton
+        title="지출 내역 보러가기"
+        style="mb-0"
+        onClick={() => moveToPage(PageUrls.PAY_RECODE)}
+      />
     </BoxWrapper>
   );
 };
 
-const PayOfCategory = () => {
+export interface CategoryPay {
+  id: number;
+  category: string;
+  budgetPrice: number;
+  spendPrice: number;
+  percentage: number;
+}
+
+const PayOfCategory: React.FC<{ categoryPay: CategoryPay[] }> = ({
+  categoryPay,
+}) => {
+  const { moveToPage } = useMovePage();
+  const sortedCategoryPay = categoryPay.sort(
+    (a: CategoryPay, b: CategoryPay) => b.spendPrice - a.spendPrice,
+  );
+
   return (
     <BoxWrapper>
       <div>카테고리 별 지출</div>
       <div className="py-5">
-        <DoughnutChart />
+        <DoughnutChart categoryPay={sortedCategoryPay} />
       </div>
-      <div className="flex flex-col gap-6 px-6 py-3 rounded-lg bg-second-bg">
-        {categoryList.map((category) => (
+      <div className="flex flex-col gap-6 rounded-lg bg-second-bg px-6 py-3">
+        {sortedCategoryPay.map((pay) => (
           <div
-            key={category.text}
+            key={pay.category}
             className="flex items-center gap-3 text-sm font-medium"
           >
             <div
               className="grid w-14 place-items-center rounded-lg py-1.5 text-white"
-              style={{ backgroundColor: category.border }}
+              style={{ backgroundColor: findCategory(pay.category)!.border }}
             >
-              13%
+              {pay.percentage}%
             </div>
-            <div className="font-normal">{category.text}</div>
-            <div className="text-base text-right grow">100,000원</div>
+            <div className="font-normal">{pay.category}</div>
+            <div className="grow text-right text-base">{pay.spendPrice}원</div>
           </div>
         ))}
       </div>
-      <SaveButton title="카테고리 별 예산 설정하러 가기" style="mb-0" />
+      <SaveButton
+        onClick={() => {
+          moveToPage(PageUrls.BUDGET_SET);
+        }}
+        title="카테고리 별 예산 설정하러 가기"
+        style="mb-0"
+      />
     </BoxWrapper>
   );
 };
 
+interface BudgetData {
+  totalId: number;
+  totalBudget: number;
+  totalSpend: number;
+  totalPercentage: number;
+  budgetInfoList: CategoryPay[];
+}
+
 const StatisticPage = () => {
+  const [budgetData, setBudgetData] = useState<BudgetData>({
+    totalId: 0,
+    totalBudget: 0,
+    totalSpend: 0,
+    totalPercentage: 0,
+    budgetInfoList: [],
+  });
+  const getBudget = async () => {
+    try {
+      const res = await api.get("/budget");
+      console.log(res.data.result);
+      setBudgetData(res.data.result);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+  useEffect(() => {
+    getBudget();
+  }, []);
   return (
-    <div className="flex flex-col w-full gap-5 py-6">
-      <MonthPayBox />
+    <div className="flex w-full flex-col gap-5 py-6">
+      <MonthPayBox
+        monthPay={budgetData.totalSpend}
+        restBudget={budgetData.totalBudget - budgetData.totalSpend}
+      />
       <PrevMonthPayBox />
-      <PayOfCategory />
+      <PayOfCategory categoryPay={[...budgetData.budgetInfoList]} />
     </div>
   );
 };

--- a/src/pages/StatisticPage.tsx
+++ b/src/pages/StatisticPage.tsx
@@ -1,7 +1,6 @@
 import { LucideChevronRight } from "lucide-react";
 import React, { ReactNode, useEffect, useState } from "react";
 import { SaveButton } from "../components/common/Buttons";
-import { categoryList } from "../constants/category";
 import BarChart from "../components/charts/BarChart";
 import DoughnutChart from "../components/charts/DoughnutChart";
 import BarGraph from "../components/BarGraph";
@@ -10,6 +9,13 @@ import { formatPrice } from "../utils/formatFunc";
 import { useMovePage } from "../hooks/useMovePage";
 import PageUrls from "../constants/PageUrls";
 import { findCategory } from "../utils/findTypeOrCategory";
+
+export interface AnalyticsData {
+  category: string;
+  price: number;
+  percentage: number;
+  date: string;
+}
 
 const BoxWrapper: React.FC<{ children: ReactNode }> = ({ children }) => {
   return (
@@ -24,6 +30,7 @@ const MonthPayBox: React.FC<{ monthPay: number; restBudget: number }> = ({
   restBudget,
 }) => {
   const { moveToPage } = useMovePage();
+
   return (
     <BoxWrapper>
       <div>이번 달 지출</div>
@@ -35,19 +42,33 @@ const MonthPayBox: React.FC<{ monthPay: number; restBudget: number }> = ({
         <LucideChevronRight size={24} color="#333" />
       </div>
       <div className="py-2.5">
-        <BarGraph props={40} height="h-5" />
+        <BarGraph
+          props={Math.abs(Math.floor((monthPay / restBudget) * 100))}
+          height="h-5"
+        />
       </div>
 
       <div className="flex items-center justify-between">
-        <div>남은예산</div>
-        <div className="text-xl font-medium">{formatPrice(restBudget)}원</div>
+        {restBudget < 0 ? (
+          <div className="text-main">초과예산</div>
+        ) : (
+          <div>남은예산</div>
+        )}
+        <div className="text-xl font-medium">
+          {formatPrice(Math.abs(restBudget))}원
+        </div>
       </div>
     </BoxWrapper>
   );
 };
 
-const PrevMonthPayBox = () => {
+const PrevMonthPayBox: React.FC<{
+  monthPay: any;
+  prevPay: any;
+  twoMonthsAgoPay: any;
+}> = ({ monthPay, prevPay, twoMonthsAgoPay }) => {
   const { moveToPage } = useMovePage();
+
   return (
     <BoxWrapper>
       <div>지난 달보다</div>
@@ -56,7 +77,11 @@ const PrevMonthPayBox = () => {
         <div>더 쓰고 있어요</div>
       </div>
       <div className="py-5">
-        <BarChart />
+        <BarChart
+          monthPay={monthPay.analyicsInfoDTOS}
+          prevPay={prevPay.analyicsInfoDTOS}
+          twoMonthsAgoPay={twoMonthsAgoPay.analyicsInfoDTOS}
+        />
       </div>
       <SaveButton
         title="지출 내역 보러가기"
@@ -67,30 +92,27 @@ const PrevMonthPayBox = () => {
   );
 };
 
-export interface CategoryPay {
-  id: number;
-  category: string;
-  budgetPrice: number;
-  spendPrice: number;
-  percentage: number;
-}
-
-const PayOfCategory: React.FC<{ categoryPay: CategoryPay[] }> = ({
-  categoryPay,
-}) => {
+const PayOfCategory: React.FC<{ categoryPay: any }> = ({ categoryPay }) => {
   const { moveToPage } = useMovePage();
-  const sortedCategoryPay = categoryPay.sort(
-    (a: CategoryPay, b: CategoryPay) => b.spendPrice - a.spendPrice,
+  const sortedCategoryPay = categoryPay.analyicsInfoDTOS.sort(
+    (a: AnalyticsData, b: AnalyticsData) => b.price - a.price,
+  );
+
+  const totalPay = sortedCategoryPay.reduce(
+    (acc: number, cur: AnalyticsData) => {
+      return (acc += cur.price);
+    },
+    0,
   );
 
   return (
     <BoxWrapper>
       <div>카테고리 별 지출</div>
       <div className="py-5">
-        <DoughnutChart categoryPay={sortedCategoryPay} />
+        <DoughnutChart categoryPay={categoryPay} />
       </div>
       <div className="flex flex-col gap-6 rounded-lg bg-second-bg px-6 py-3">
-        {sortedCategoryPay.map((pay) => (
+        {sortedCategoryPay.map((pay: AnalyticsData) => (
           <div
             key={pay.category}
             className="flex items-center gap-3 text-sm font-medium"
@@ -99,10 +121,10 @@ const PayOfCategory: React.FC<{ categoryPay: CategoryPay[] }> = ({
               className="grid w-14 place-items-center rounded-lg py-1.5 text-white"
               style={{ backgroundColor: findCategory(pay.category)!.border }}
             >
-              {pay.percentage}%
+              {Math.floor((pay.price / totalPay) * 100)}%
             </div>
             <div className="font-normal">{pay.category}</div>
-            <div className="grow text-right text-base">{pay.spendPrice}원</div>
+            <div className="grow text-right text-base">{pay.price}원</div>
           </div>
         ))}
       </div>
@@ -116,6 +138,14 @@ const PayOfCategory: React.FC<{ categoryPay: CategoryPay[] }> = ({
     </BoxWrapper>
   );
 };
+
+interface CategoryPay {
+  id: number;
+  category: string;
+  budgetPrice: number;
+  spendPrice: number;
+  percentage: number;
+}
 
 interface BudgetData {
   totalId: number;
@@ -133,26 +163,59 @@ const StatisticPage = () => {
     totalPercentage: 0,
     budgetInfoList: [],
   });
+  const [analyticsData, setAnalyticsData] = useState();
+  const getAnalytics = async () => {
+    try {
+      const res = await api.get("/analytics");
+      return res.data.result;
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  };
   const getBudget = async () => {
     try {
       const res = await api.get("/budget");
-      console.log(res.data.result);
-      setBudgetData(res.data.result);
+      return res.data.result;
     } catch (error) {
-      console.error(error);
+      return Promise.reject(error);
     }
   };
   useEffect(() => {
-    getBudget();
+    const getInfos = async () => {
+      const results = await Promise.allSettled([getAnalytics(), getBudget()]);
+
+      const analyticsResult = results[0];
+      const budgetResult = results[1];
+
+      if (analyticsResult.status === "fulfilled") {
+        setAnalyticsData(analyticsResult.value);
+      } else {
+        console.error(analyticsResult.reason);
+      }
+
+      if (budgetResult.status === "fulfilled") {
+        setBudgetData(budgetResult.value);
+      } else {
+        console.error(budgetResult.reason);
+      }
+    };
+    getInfos();
   }, []);
+
   return (
     <div className="flex w-full flex-col gap-5 py-6">
       <MonthPayBox
         monthPay={budgetData.totalSpend}
         restBudget={budgetData.totalBudget - budgetData.totalSpend}
       />
-      <PrevMonthPayBox />
-      <PayOfCategory categoryPay={[...budgetData.budgetInfoList]} />
+      {analyticsData && (
+        <PrevMonthPayBox
+          monthPay={analyticsData[0] || []}
+          prevPay={analyticsData[1] || []}
+          twoMonthsAgoPay={analyticsData[2] || []}
+        />
+      )}
+      {analyticsData && <PayOfCategory categoryPay={analyticsData[0] || []} />}
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣ 요약 설명
통계 페이지 api 연동

## 📝 작업 내용
통계 페이지 api 연동("/budget", "analytics" 둘 다 호출) 


```javascript
const results = await Promise.allSettled([getAnalytics(), getBudget()]);

```
두 개의 api를 allSettled로 묶어서 전송

## 💻 동작 확인
<img width="324" alt="image" src="https://github.com/user-attachments/assets/494cdb9d-6057-4517-a033-01359031c34a" />
<img width="326" alt="image" src="https://github.com/user-attachments/assets/46a74f28-9af6-4f3d-81a6-bfb00bd87361" />

## 👀 이미지 첨부(선택)

> 퍼블리싱이나 변경된 디자인이 있다면 사진을 올려주세요
>
> ex) 버튼 색상 변경되었습니다

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?